### PR TITLE
Don't save imgui.ini state files.

### DIFF
--- a/app.cpp
+++ b/app.cpp
@@ -296,6 +296,10 @@ void SaveFile(std::string path) {
 void MainInit(int argc, char** argv, int initial_width, int initial_height) {
     appState.timeline_width = initial_width * 0.8f;
 
+    // Don't auto-save imgui.ini state file
+    ImGuiIO& io = ImGui::GetIO();
+    io.IniFilename = NULL;
+
     ApplyAppStyle();
 
     LoadFonts();


### PR DESCRIPTION
By default Dear ImGui saves application state to an imgui.ini file in the current directory. Currently Raven leaves these little state files all over the place. This change prevents saving that state to disk, avoiding clutter.