### PR TITLE
Fix log

### DIFF
--- a/app.cpp
+++ b/app.cpp
@@ -42,7 +42,7 @@ void Log(const char* format, ...) {
     va_list args;
     va_start(args, format);
     fprintf(stderr, "LOG: ");
-    fprintf(stderr, format, args);
+    vfprintf(stderr, format, args);
     fprintf(stderr, "\n");
     va_end(args);
 }


### PR DESCRIPTION
This fixes the `Log(format, ...)` to properly handle variable argument lists. Without this fix only a single % replacement worked properly.