### PR TITLE
Enable/Disable Clips

### DIFF
--- a/inspector.cpp
+++ b/inspector.cpp
@@ -516,6 +516,7 @@ void DrawInspector() {
             if (item_color != "") {
                 SetItemColor(item, item_color);
             }
+            bool x = ImGui::Checkbox("Enabled", &item->_enabled);
         }
 
         auto trimmed_range = item->trimmed_range();

--- a/timeline.cpp
+++ b/timeline.cpp
@@ -2,9 +2,9 @@
 
 #include "timeline.h"
 #include "app.h"
-#include "colors.h"
-#include "editing.h"
 #include "widgets.h"
+#include "editing.h"
+#include "colors.h"
 
 #include <opentimelineio/clip.h>
 #include <opentimelineio/composable.h>
@@ -12,8 +12,8 @@
 #include <opentimelineio/gap.h>
 #include <opentimelineio/linearTimeWarp.h>
 #include <opentimelineio/marker.h>
-#include <opentimelineio/track.h>
 #include <opentimelineio/transition.h>
+#include <opentimelineio/track.h>
 
 // counters to measure visibility-check performance optimization
 static int __tracks_rendered;
@@ -30,13 +30,13 @@ TimeScalarForItem(otio::Item* item) {
     return time_scalar;
 }
 
-// otio::RationalTime TopLevelTime(otio::RationalTime time, otio::Item* context) {
-//   return context->transformed_time(time, appState.timeline->tracks());
-// }
+//otio::RationalTime TopLevelTime(otio::RationalTime time, otio::Item* context) {
+//  return context->transformed_time(time, appState.timeline->tracks());
+//}
 //
-// otio::TimeRange TopLevelTimeRange(otio::TimeRange range, otio::Item* context) {
-//   return context->transformed_time_range(range, appState.timeline->tracks());
-// }
+//otio::TimeRange TopLevelTimeRange(otio::TimeRange range, otio::Item* context) {
+//  return context->transformed_time_range(range, appState.timeline->tracks());
+//}
 
 // Transform this range map from the context item's coodinate space
 // into the top-level timeline's coordinate space. This compensates for
@@ -367,7 +367,7 @@ void DrawEffects(
     }
     auto item_range = range_it->second;
 
-    ImVec2 size(width, height * 0.75);
+    ImVec2 size(width, height*0.75);
 
     // Does the label fit in the available space?
     bool label_visible = (size.x > text_size.x && label_str != "");
@@ -629,13 +629,13 @@ void DrawTrackLabel(otio::Track* track, int index, float height) {
     ImGui::AlignTextToFramePadding();
     ImVec2 size(width, height);
     ImGui::InvisibleButton("##empty", size);
-
+    
     std::string kind(track->kind());
-    if (kind.empty()) {
+    if(kind.empty()) {
         // fallback when kind is not set
         kind = "Other";
     }
-
+    
     char label_str[200];
     snprintf(
         label_str,
@@ -1295,9 +1295,12 @@ void DrawTimeline(otio::Timeline* timeline) {
 
     // get other (non-AV) tracks
     std::vector<otio::Track*> other_tracks;
-    for (auto c : timeline->tracks()->children()) {
-        if (auto t = otio::dynamic_retainer_cast<otio::Track>(c)) {
-            if (t->kind() != otio::Track::Kind::video && t->kind() != otio::Track::Kind::audio) {
+    for (auto c: timeline->tracks()->children())
+    {
+        if (auto t = otio::dynamic_retainer_cast<otio::Track>(c))
+        {
+            if (t->kind() != otio::Track::Kind::video &&  t->kind() != otio::Track::Kind::audio)
+            {
                 other_tracks.push_back(t);
             }
         }
@@ -1427,10 +1430,11 @@ void DrawTimeline(otio::Timeline* timeline) {
             }
             index++;
         }
-
+        
         // Draw other tracks
         index = (int)other_tracks.size();
-        for (auto i = other_tracks.rbegin(); i != other_tracks.rend(); ++i) {
+        for (auto i = other_tracks.rbegin(); i != other_tracks.rend(); ++i)
+        {
             const auto& other_track = *i;
             ImGui::TableNextRow(ImGuiTableRowFlags_None, appState.track_height);
             if (ImGui::TableNextColumn()) {

--- a/timeline.cpp
+++ b/timeline.cpp
@@ -2,9 +2,9 @@
 
 #include "timeline.h"
 #include "app.h"
-#include "widgets.h"
-#include "editing.h"
 #include "colors.h"
+#include "editing.h"
+#include "widgets.h"
 
 #include <opentimelineio/clip.h>
 #include <opentimelineio/composable.h>
@@ -12,8 +12,8 @@
 #include <opentimelineio/gap.h>
 #include <opentimelineio/linearTimeWarp.h>
 #include <opentimelineio/marker.h>
-#include <opentimelineio/transition.h>
 #include <opentimelineio/track.h>
+#include <opentimelineio/transition.h>
 
 // counters to measure visibility-check performance optimization
 static int __tracks_rendered;
@@ -30,13 +30,13 @@ TimeScalarForItem(otio::Item* item) {
     return time_scalar;
 }
 
-//otio::RationalTime TopLevelTime(otio::RationalTime time, otio::Item* context) {
-//  return context->transformed_time(time, appState.timeline->tracks());
-//}
+// otio::RationalTime TopLevelTime(otio::RationalTime time, otio::Item* context) {
+//   return context->transformed_time(time, appState.timeline->tracks());
+// }
 //
-//otio::TimeRange TopLevelTimeRange(otio::TimeRange range, otio::Item* context) {
-//  return context->transformed_time_range(range, appState.timeline->tracks());
-//}
+// otio::TimeRange TopLevelTimeRange(otio::TimeRange range, otio::Item* context) {
+//   return context->transformed_time_range(range, appState.timeline->tracks());
+// }
 
 // Transform this range map from the context item's coodinate space
 // into the top-level timeline's coordinate space. This compensates for
@@ -99,6 +99,10 @@ void DrawItem(
     if (item_color != "") {
         fill_color = UIColorFromName(item_color);
         fill_color = TintedColorForUI(fill_color);
+    }
+
+    if (!item->enabled()) {
+        fill_color = UIColorFromName("");
     }
 
     if (auto gap = dynamic_cast<otio::Gap*>(item)) {
@@ -363,7 +367,7 @@ void DrawEffects(
     }
     auto item_range = range_it->second;
 
-    ImVec2 size(width, height*0.75);
+    ImVec2 size(width, height * 0.75);
 
     // Does the label fit in the available space?
     bool label_visible = (size.x > text_size.x && label_str != "");
@@ -625,13 +629,13 @@ void DrawTrackLabel(otio::Track* track, int index, float height) {
     ImGui::AlignTextToFramePadding();
     ImVec2 size(width, height);
     ImGui::InvisibleButton("##empty", size);
-    
+
     std::string kind(track->kind());
-    if(kind.empty()) {
+    if (kind.empty()) {
         // fallback when kind is not set
         kind = "Other";
     }
-    
+
     char label_str[200];
     snprintf(
         label_str,
@@ -1291,12 +1295,9 @@ void DrawTimeline(otio::Timeline* timeline) {
 
     // get other (non-AV) tracks
     std::vector<otio::Track*> other_tracks;
-    for (auto c: timeline->tracks()->children())
-    {
-        if (auto t = otio::dynamic_retainer_cast<otio::Track>(c))
-        {
-            if (t->kind() != otio::Track::Kind::video &&  t->kind() != otio::Track::Kind::audio)
-            {
+    for (auto c : timeline->tracks()->children()) {
+        if (auto t = otio::dynamic_retainer_cast<otio::Track>(c)) {
+            if (t->kind() != otio::Track::Kind::video && t->kind() != otio::Track::Kind::audio) {
                 other_tracks.push_back(t);
             }
         }
@@ -1426,11 +1427,10 @@ void DrawTimeline(otio::Timeline* timeline) {
             }
             index++;
         }
-        
+
         // Draw other tracks
         index = (int)other_tracks.size();
-        for (auto i = other_tracks.rbegin(); i != other_tracks.rend(); ++i)
-        {
+        for (auto i = other_tracks.rbegin(); i != other_tracks.rend(); ++i) {
             const auto& other_track = *i;
             ImGui::TableNextRow(ImGuiTableRowFlags_None, appState.track_height);
             if (ImGui::TableNextColumn()) {


### PR DESCRIPTION
This is a Work-In-Progress Pull Request meant to solve #19 

Summary of Changes (WIP)
---
`inspector.cpp`
- added 'Enabled' checkbox for non-Gap items (Tracks and Clips) using `ImGui::Checkbox()`:
![image](https://github.com/OpenTimelineIO/raven/assets/78163326/2c24cc57-ef97-402e-9922-7a6fa0a86f37)


`timeline.cpp`
- In `DrawItem()`, added conditional graying out on disabled items
  - Disabled non-Gap items have a gray `fill_color` 
  (obtained by calling `UIColorFromName("")`  to get `IM_COL32(0x88, 0x88, 0x88, 0xff)`).
- Disabled tracks look like this:
![image](https://github.com/OpenTimelineIO/raven/assets/78163326/09d6d400-6d8e-4f26-8506-bba8160847e8)
- The color change seems to **apply only to disabled clips** and **not  disabled tracks**
- The current color for disabled items is just a placeholder until I can find a better color to use.

Request for help - Use Checkbox while keeping `Item::_enabled` private 
---
The `ImGui::Checkbox()` only works as presented if `Item::_enabled` data member is exposed (made a non-private data member).
I couldn't get the checkbox to work otherwise. I tried using the public getter/setter methods (`Item::enabled()` and `Item::set_enabled()`) to make the checkbox functional but the checkbox would quickly un-tick itself once enabled.

I'd appreciate any advice on how to add a functional checkbox while keeping `Item::_enabled` private.
