### PR TITLE
Clarify WASM status in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ You will need to install the [Emscripten toolchain](https://emscripten.org) firs
 See also: `serve.py` as an alternative to `emrun`, and as
 a reference for which HTTP headers are needed to host the WASM build.
 
+Note: The WASM build of raven is missing some features - see the Help Wanted section below.
+
 ## Troubleshooting
 
 If you have trouble building, these hints might help...


### PR DESCRIPTION
This PR just adds a note to the README clarifying the status of the WASM build of raven.