### PR TITLE
Added an "Effects" tab to the inspector.

### DIFF
--- a/app.cpp
+++ b/app.cpp
@@ -428,7 +428,7 @@ void MainGui() {
         ImGuiID dock_id_side = ImGui::DockBuilderSplitNode(
             dock_main_id,
             ImGuiDir_Right,
-            0.25f,
+            0.3f,
             NULL,
             &dock_main_id);
 
@@ -436,6 +436,7 @@ void MainGui() {
         ImGui::DockBuilderDockWindow("Inspector", dock_id_side);
         ImGui::DockBuilderDockWindow("JSON", dock_id_side);
         ImGui::DockBuilderDockWindow("Markers", dock_id_side);
+        ImGui::DockBuilderDockWindow("Effects", dock_id_side);
         ImGui::DockBuilderDockWindow("Settings", dock_id_side);
         ImGui::DockBuilderFinish(dockspace_id);
     }
@@ -491,6 +492,13 @@ void MainGui() {
     visible = ImGui::Begin("Markers", NULL, window_flags);
     if (visible) {
         DrawMarkersInspector();
+    }
+    ImGui::End();
+
+    ImGui::SetNextWindowDockID(dockspace_id, ImGuiCond_FirstUseEver);
+    visible = ImGui::Begin("Effects", NULL, window_flags);
+    if (visible) {
+        DrawEffectsInspector();
     }
     ImGui::End();
 

--- a/inspector.cpp
+++ b/inspector.cpp
@@ -2,6 +2,7 @@
 
 #include "inspector.h"
 #include "app.h"
+#include "libs/imgui/imgui.h"
 #include "widgets.h"
 #include "editing.h"
 #include "colors.h"
@@ -656,7 +657,7 @@ void DrawMarkersInspector() {
             auto marker = pair.first;
             auto parent = pair.second;
 
-            ImGui::PushID(&marker);
+            ImGui::PushID(marker.value);
             ImGui::TableNextRow();
 
             // Local Time
@@ -753,14 +754,14 @@ void DrawEffectsInspector() {
             auto effect = pair.first;
             auto parent = pair.second;
 
-            ImGui::PushID(&effect);
+            ImGui::PushID(effect.value);
             ImGui::TableNextRow();
 
             // Global Time
             ImGui::TableNextColumn();
 
-            auto range = parent->source_range();
-            auto global_time = parent->transformed_time(range->start_time(), root) + global_start;
+            auto range = parent->trimmed_range();
+            auto global_time = parent->transformed_time(range.start_time(), root) + global_start;
 
             // Make this row selectable & jump the playhead when clicked
             auto is_selected =

--- a/inspector.cpp
+++ b/inspector.cpp
@@ -670,6 +670,7 @@ void DrawMarkersInspector() {
 
             auto global_time = parent->transformed_time(range.start_time(), root) + global_start;
 
+            // Make this row selectable & jump the playhead when clicked
             auto is_selected =
                 (appState.selected_object == marker) ||
                 (appState.selected_object == parent);
@@ -696,6 +697,93 @@ void DrawMarkersInspector() {
             ImGui::SameLine();
 
             ImGui::TextUnformatted(marker->name().c_str());
+
+            // Item
+            ImGui::TableNextColumn();
+
+            ImGui::TextUnformatted(parent->name().c_str());
+
+            ImGui::PopID();
+        }
+    }
+    ImGui::EndTable();
+}
+
+void DrawEffectsInspector() {
+    typedef std::pair<otio::SerializableObject::Retainer<otio::Effect>, otio::SerializableObject::Retainer<otio::Item>> effect_parent_pair;
+    std::vector<effect_parent_pair> pairs;
+
+    auto root = appState.timeline->tracks();
+    auto global_start = appState.timeline->global_start_time().value_or(otio::RationalTime());
+
+    for (const auto& effect : root->effects()) {
+        pairs.push_back(effect_parent_pair(effect, root));
+    }
+
+    for (const auto& child :
+         appState.timeline->tracks()->find_children())
+    {
+        if (const auto& item = dynamic_cast<otio::Item*>(&*child))
+        {
+            for (const auto& effect : item->effects()) {
+                pairs.push_back(effect_parent_pair(effect, item));
+            }
+        }
+    }
+
+    auto selectable_flags = ImGuiSelectableFlags_SpanAllColumns | ImGuiSelectableFlags_AllowItemOverlap;
+
+    if (ImGui::BeginTable("Effects",
+                          4,
+//                          ImGuiTableFlags_Sortable |
+                          ImGuiTableFlags_NoSavedSettings |
+                          ImGuiTableFlags_Resizable |
+                          ImGuiTableFlags_Reorderable |
+                          ImGuiTableFlags_Hideable))
+    {
+        ImGui::TableSetupColumn("Global Time", ImGuiTableColumnFlags_WidthFixed);
+        ImGui::TableSetupColumn("Name", ImGuiTableColumnFlags_WidthStretch);
+        ImGui::TableSetupColumn("Effect", ImGuiTableColumnFlags_WidthStretch);
+        ImGui::TableSetupColumn("Item", ImGuiTableColumnFlags_WidthStretch);
+
+        ImGui::TableHeadersRow();
+
+        for (const auto& pair : pairs)
+        {
+            auto effect = pair.first;
+            auto parent = pair.second;
+
+            ImGui::PushID(&effect);
+            ImGui::TableNextRow();
+
+            // Global Time
+            ImGui::TableNextColumn();
+
+            auto range = parent->source_range();
+            auto global_time = parent->transformed_time(range->start_time(), root) + global_start;
+
+            // Make this row selectable & jump the playhead when clicked
+            auto is_selected =
+                (appState.selected_object == effect) ||
+                (appState.selected_object == parent);
+            if (ImGui::Selectable(TimecodeStringFromTime(global_time).c_str(),
+                                    is_selected,
+                                    selectable_flags)) {
+                printf("DEBUG: clicked %s\n", TimecodeStringFromTime(global_time).c_str());
+                appState.playhead = global_time;
+                SelectObject(effect, parent);
+                appState.scroll_to_playhead = true;
+            }
+
+            // Name
+            ImGui::TableNextColumn();
+
+            ImGui::TextUnformatted(effect->name().c_str());
+
+            // Effect
+            ImGui::TableNextColumn();
+
+            ImGui::TextUnformatted(effect->effect_name().c_str());
 
             // Item
             ImGui::TableNextColumn();

--- a/inspector.h
+++ b/inspector.h
@@ -3,3 +3,4 @@
 void DrawInspector();
 void DrawJSONInspector();
 void DrawMarkersInspector();
+void DrawEffectsInspector();


### PR DESCRIPTION
Adding a "Effects" tab to the inspector which shows a list of all the effects in the OTIO. This is similar to the existing "Markers" tab. Clicking an effect in the list, moves the playhead to the associated clip in the timeline. This is useful for quickly finding specific effects without manually hunting through each clip.

![image](https://github.com/OpenTimelineIO/raven/assets/169599/50371072-975d-4b5e-8d2c-be54b77c00e2)
