### PR TITLE
Improve clip and transition color changes on hover and select

### DIFF
--- a/timeline.cpp
+++ b/timeline.cpp
@@ -98,14 +98,15 @@ void DrawItem(
     auto item_color = GetItemColor(item);
     if (item_color != "") {
         fill_color = UIColorFromName(item_color);
-        fill_color = TintedColorForUI(fill_color);
+        selected_fill_color = TintedColorForUI(fill_color);
+        hover_fill_color = TintedColorForUI(fill_color);
     }
 
     if (auto gap = dynamic_cast<otio::Gap*>(item)) {
         // different colors & style
         fill_color = appTheme.colors[AppThemeCol_Background];
-        selected_fill_color = appTheme.colors[AppThemeCol_GapSelected];
-        hover_fill_color = appTheme.colors[AppThemeCol_GapHovered];
+        selected_fill_color = TintedColorForUI(fill_color);
+        hover_fill_color = TintedColorForUI(fill_color);
         label_str = "";
         fancy_corners = false;
         show_time_range = false;
@@ -584,8 +585,8 @@ void DrawObjectLabel(otio::SerializableObjectWithMetadata* object, float height)
 
     auto label_color = appTheme.colors[AppThemeCol_Label];
     auto fill_color = appTheme.colors[AppThemeCol_Track];
-    auto selected_fill_color = appTheme.colors[AppThemeCol_TrackSelected];
-    auto hover_fill_color = appTheme.colors[AppThemeCol_TrackHovered];
+    auto selected_fill_color = TintedColorForUI(fill_color);
+    auto hover_fill_color = TintedColorForUI(fill_color);
 
     ImVec2 text_offset(5.0f, 5.0f);
 

--- a/timeline.cpp
+++ b/timeline.cpp
@@ -274,6 +274,12 @@ void DrawTransition(
     auto selected_fill_color = appTheme.colors[AppThemeCol_TransitionSelected];
     auto hover_fill_color = appTheme.colors[AppThemeCol_TransitionHovered];
 
+    if (ColorIsBright(fill_color)) {
+        auto inverted_fill_color = ColorInvert(fill_color);
+        selected_fill_color = TintedColorForUI(inverted_fill_color);
+        hover_fill_color = TintedColorForUI(inverted_fill_color);
+    } 
+
     auto old_pos = ImGui::GetCursorPos();
     ImGui::SetCursorPos(render_pos);
 


### PR DESCRIPTION
## Summary
There were a couple of improvements that were needed to make Clips more viewable and interactive. This MR aims to improve the overall colouring of Clips (and transitions) when performing actions like hovering and selection.

## List of changes
- Previously, selecting a clip color from the inspector window did not actually apply the color to the clip until it was deselected. This PR fixes that bug.
- Instead of using hard-coded color values to determine the hover and selection fill colours for clips, we use the configured color (if available in the raven metadata) and apply a tint to it. This makes the user's interaction with a specific clip more intuitive, indicating to them more clearly which clip is being hovered over / selected.
- Upon trying out some of the example files, I realized that this kind of logic could also be applied to make the transition elements look cleaner during cursor interaction, so I have included that within the scope of this task.

## Examples

1. Hover and selecting clips:
    ![holver-and-select-tint](https://github.com/user-attachments/assets/cc00bf94-705f-45ef-a932-6ec0bdc8d89e)

3. Coloring clips:
    ![coloring-clips](https://github.com/user-attachments/assets/31df659c-ae10-48f4-9c6a-35ef8be7f3db)

4. Hovering and selecting transitions:
    ![hover-and-select-transitions](https://github.com/user-attachments/assets/7021ecef-4397-4439-9b1b-113347bfce8a)


Fixes #20 