### PR TITLE
Add media reference to inspector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 
 
 build
+.vscode
 *.DS_Store

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This will also clone and initialize all of the submodules that this project depe
 
 ## Building (macOS, Windows, Linux)
 
-Spin up your favourite terminal and follow these steps:
+Spin up your favorite terminal and follow these steps:
 
 ```shell
   git clone --recursive https://github.com/OpenTimelineIO/raven.git

--- a/app.h
+++ b/app.h
@@ -127,6 +127,9 @@ struct AppState {
     char message[1024]; // single-line message displayed in main window
     bool message_is_error = false;
 
+    // Store the currently selected MediaReference index for the inspector.
+    int selected_reference_index = -1;
+
     // Toggles for Dear ImGui windows
     bool show_main_window = true;
     bool show_style_editor = false;


### PR DESCRIPTION
This is a Work-In-Progress Pull Request meant to solve: https://github.com/OpenTimelineIO/raven/issues/62

### Changes

Main Changes:

- Add new section to inspector to view and modify Media References
- Supports MissingMediaReference, ExternalReference, and ImageSequenceReference classes
- Add attributes for:
- - Available Image Bounds
- - Available range
- - Target/Target URL base
- - Selected media reference
- - Metadata

Minor Changes:
- Vscode is changing the import order of implot
- Added the vscode config file to the gitignore for anyone else using vscode

Examples:

![2024-09-27 11 49 53](https://github.com/user-attachments/assets/6eb82f1e-76e9-46f9-abe7-e51dba97ae26)

![2024-09-27 11 49 00](https://github.com/user-attachments/assets/7e7980be-ae1c-436d-952f-58b7d34c7a56)

