### PR TITLE
Add drag & drop functionality for opening files (in macOS)

### DIFF
--- a/app.cpp
+++ b/app.cpp
@@ -38,8 +38,8 @@ AppTheme appTheme;
 
 ImFont* gFont = nullptr;
 
-// Variables to store the state of dropped files
-std::string prompt_dropped_file = ""; // The file asking for the opened
+// Variable to store dropped file to load
+std::string prompt_dropped_file = "";
 
 // Log a message to the terminal
 void Log(const char* format, ...) {

--- a/app.cpp
+++ b/app.cpp
@@ -335,10 +335,6 @@ bool is_valid_file(const std::string& filepath) {
 
 // Accept and open a file path
 void FileDropCallback(int count, const char** filepaths) {
-    // Validate only one file
-    // validate file type
-    // pop up confirmation
-
     if (count > 1){
         Message("Cannot open multiple files.");
         return;

--- a/app.cpp
+++ b/app.cpp
@@ -22,6 +22,7 @@
 
 void DrawMenu();
 void DrawToolbar(ImVec2 buttonSize);
+void DrawDroppedFilesPrompt();
 
 #define DEFINE_APP_THEME_NAMES
 #include "app.h"
@@ -36,6 +37,9 @@ AppState appState;
 AppTheme appTheme;
 
 ImFont* gFont = nullptr;
+
+// Variables to store the state of dropped files
+std::string prompt_dropped_file = ""; // The file asking for the opened
 
 // Log a message to the terminal
 void Log(const char* format, ...) {
@@ -315,6 +319,47 @@ void MainInit(int argc, char** argv, int initial_width, int initial_height) {
 
 void MainCleanup() { }
 
+// Validate that a file has the .otio extension
+bool is_valid_file(const std::string& filepath) {
+    size_t last_dot = filepath.find_last_of('.');
+    
+    // If no dot is found, it's not a valid file
+    if (last_dot == std::string::npos) {
+        return false;
+    }
+
+    // Get and check the extension
+    std::string extension = filepath.substr(last_dot + 1);
+    return extension == "otio";
+}
+
+// Accept and open a file path
+void FileDropCallback(int count, const char** filepaths) {
+    // Validate only one file
+    // validate file type
+    // pop up confirmation
+
+    if (count > 1){
+        Message("Cannot open multiple files.");
+        return;
+    }
+
+    else if (count == 0) {
+        return;
+    }
+
+    std::string file_path = filepaths[0];
+
+    if (!is_valid_file(file_path)){
+        Message("Invalid file: %s", file_path.c_str());
+        return;
+    }
+
+    // Loading is done in DrawDroppedFilesPrompt()
+    prompt_dropped_file = file_path;
+
+}
+
 // Make a button using the fancy icon font
 bool IconButton(const char* label, const ImVec2 size = ImVec2(0, 0)) {
     bool result = ImGui::Button(label, size);
@@ -383,6 +428,7 @@ void MainGui() {
         exit(0);
     }
 
+    DrawDroppedFilesPrompt();
     DrawMenu();
 
     // ImGui::SameLine(ImGui::GetContentRegionAvailWidth() - button_size.x +
@@ -783,6 +829,32 @@ void DrawToolbar(ImVec2 button_size) {
     ImGui::SameLine();
     ImGui::Text("Frame: %d @ %3d fps", ImGui::GetFrameCount(), fps);
 #endif
+}
+
+// Prompt the user to confirm file loading
+void DrawDroppedFilesPrompt() {
+    if (prompt_dropped_file == "") {
+        return;
+    }
+
+    ImGui::OpenPopup("Open File?");
+    // Modal window for confirmation
+    if (ImGui::BeginPopupModal("Open File?", nullptr, ImGuiWindowFlags_AlwaysAutoResize)) {
+        ImGui::Text("Open file \n%s?", prompt_dropped_file.c_str());
+        
+        if (ImGui::Button("Yes")) {
+            LoadFile(prompt_dropped_file);
+            prompt_dropped_file = "";
+            ImGui::CloseCurrentPopup();
+        }
+        ImGui::SameLine();
+        if (ImGui::Button("No")) {
+            Message(""); // Reset last message
+            prompt_dropped_file = "";
+            ImGui::CloseCurrentPopup();
+        }
+        ImGui::EndPopup();
+    }
 }
 
 void SelectObject(

--- a/main.h
+++ b/main.h
@@ -2,4 +2,4 @@
 void MainInit(int argc, char** argv, int initial_width, int initial_height);
 void MainGui();
 void MainCleanup();
-
+void FileDropCallback(int count, const char** paths);

--- a/main_macos.mm
+++ b/main_macos.mm
@@ -18,6 +18,11 @@
 #import <Metal/Metal.h>
 #import <QuartzCore/QuartzCore.h>
 
+// Accept and open a file path
+void file_drop_callback(GLFWwindow* window, int count, const char** paths) {
+    FileDropCallback(count, paths);
+}
+
 static void glfw_error_callback(int error, const char* description)
 {
     fprintf(stderr, "Glfw Error %d: %s\n", error, description);
@@ -99,6 +104,9 @@ int main(int argc, char** argv)
 
     // Our state
     float clear_color[4] = {0.45f, 0.55f, 0.60f, 1.00f};
+
+    // Set the drop callback
+    glfwSetDropCallback(window, file_drop_callback);
 
     // Main loop
     while (!glfwWindowShouldClose(window))


### PR DESCRIPTION
### Summary
This allows the user to drag and drop files from the file system onto the app to be opened, a pop up window will prompt the user for confirmation.

**NOTE: For Dev Days I only have macOS setup for building, so this PR only addresses that OS. I believe the functionality needs to be implemented for each platform.**

### Change List
- Added general functionality to accept dropped files in the main app (app.cpp)
- Added validation for:
  - Single dropped file: Only accepting a single file, but this case easily be expanded in the future when multiple timelines are allowed.
  - File type: Validates that the given file is valid and has the .otio extension
- Modal pop up to get user confirmation before opening the file
- Enabled file drop callback for macOS (only macOS in this PR, see note above)

### Testing
I tested the following with a file currently loaded and with an empty session.
- Drop multiple files: Aborts loading and warns the user.
- Drop directory: Aborts and warns user about invalid file.
- Drop invalid file (i.e.: .cpp file): Aborts and warns user about invalid file.
- Drop valid .otio file:
  - Click "No" in prompt: Closes prompt, aborts loading and nothing changes in the session.
  - Click "Yes" in prompt: Closes prompt and loads dropped file.

### Examples
**Open a valid file**

https://github.com/user-attachments/assets/fe9f3bd1-2483-40ae-9b57-c8a4eac69dd9

**Invalid files and user clicking "No"**

https://github.com/user-attachments/assets/b1a616ef-8e39-4248-92de-95a3e4a9b382





---
Fixes #57 