### PR TITLE
Enable/Disable Clips

### DIFF
--- a/inspector.cpp
+++ b/inspector.cpp
@@ -517,6 +517,10 @@ void DrawInspector() {
             if (item_color != "") {
                 SetItemColor(item, item_color);
             }
+            auto enabled = item->enabled();
+            if(ImGui::Checkbox("Enabled", &enabled)){
+                item->set_enabled(enabled);
+            }
         }
 
         auto trimmed_range = item->trimmed_range();

--- a/timeline.cpp
+++ b/timeline.cpp
@@ -102,6 +102,9 @@ void DrawItem(
         hover_fill_color = TintedColorForUI(fill_color);
     }
 
+    if (!item->enabled()){
+        fill_color = UIColorFromName("");
+    }
     if (auto gap = dynamic_cast<otio::Gap*>(item)) {
         // different colors & style
         fill_color = appTheme.colors[AppThemeCol_Background];


### PR DESCRIPTION
This fixes #19 


Following @jminor's suggestion in https://github.com/OpenTimelineIO/raven/pull/27#issuecomment-1879117563, I've been able to use an `ImGui::Checkbox()` while keeping `Item::_enabled` private.

Clips will be **greyed out** when disabled. Re-enabling clips will return them to their original color.
**Tracks** can be enabled/disabled, but this PR **does not include** UI changes to distinguish enabled from disabled Tracks.

Summary of changes
---
`timeline.cpp`:
- In `DrawItem()`, added conditional greying out on disabled **clips**
- Disabled non-Gap items have a grey `fill_color` 
  - Obtained by by using `UIColorFromName("")` to get `IM_COL32(0x88, 0x88, 0x88, 0xff)`

`inspector.cpp`:
- Added an "Enabled" checkbox for non-Gap items (Tracks and Clips) using `ImGui::Checkbox()`:

![trackInspectorMenu](https://github.com/user-attachments/assets/4a399bc1-c24c-4b3f-87fb-6d6ca6aad5e1)

Below is a quick demo of enabling/disabling clips
![enabledDemo](https://github.com/user-attachments/assets/305eb83f-ae2a-4393-8493-7c1e00a87a87)


### Strech Goal (Greying of entire tracks):

I'm holding off on this stretch goal as I'm not entirely clear on the desired behaviour, such as whether to grey out the just Track header or the Track header plus every clip the Track contains. I'd be willing to work on this in a follow-up Issue, if it's alright with the team.

Thank you for your patience with this feature and for considering these changes.