### PR TITLE
Timecode track height reflects elements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 
 build
+.gitignore
 .DS_Store
 examples/TallyLog 18_39_35 - 18_40_23.aaf
 examples/TallyLog 23_42_35 - 23_42_39.xml

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,4 @@
 
 
 build
-.gitignore
-.DS_Store
-examples/TallyLog 18_39_35 - 18_40_23.aaf
-examples/TallyLog 23_42_35 - 23_42_39.xml
+*.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 
 
 build
+.DS_Store
+examples/TallyLog 18_39_35 - 18_40_23.aaf
+examples/TallyLog 23_42_35 - 23_42_39.xml

--- a/app.cpp
+++ b/app.cpp
@@ -923,7 +923,25 @@ void DetectPlayheadLimits() {
 void FitZoomWholeTimeline() {
     appState.scale = appState.timeline_width / appState.timeline->duration().to_seconds();
 }
+// GUI utility to add dynamic height to GUI elements
 
+float CalculateDynamicHeight() {
+    // Get the current font size
+    float fontSize = ImGui::GetFontSize();
+    // Get the vertical spacing from the ImGui style
+    float verticalSpacing = ImGui::GetStyle().ItemSpacing.y;
+
+    // Determine how many elements are selected
+    int visibleElementCount = 0;
+    if (appState.display_timecode) visibleElementCount++;
+    if (appState.display_frames) visibleElementCount++;
+    if (appState.display_seconds) visibleElementCount++;
+    if (appState.display_rate) visibleElementCount++;
+
+    // Set height based on selected elements
+    // Use fontSize as base height and verticalSpacing for additional height
+    return fontSize + (visibleElementCount - 1) * (fontSize + verticalSpacing);
+}
 std::string FormattedStringFromTime(otio::RationalTime time, bool allow_rate) {
     std::string result;
     if (appState.display_timecode) {

--- a/app.cpp
+++ b/app.cpp
@@ -940,7 +940,9 @@ float CalculateDynamicHeight() {
 
     // Set height based on selected elements
     // Use fontSize as base height and verticalSpacing for additional height
-    return fontSize + (visibleElementCount - 1) * (fontSize + verticalSpacing);
+    float calculatedHeight = fontSize + (visibleElementCount - 1) * (fontSize + verticalSpacing);
+        // Return the maximum of calculatedHeight and the minimum height (10)
+    return std::max(calculatedHeight, 10.0f);
 }
 std::string FormattedStringFromTime(otio::RationalTime time, bool allow_rate) {
     std::string result;

--- a/app.h
+++ b/app.h
@@ -139,6 +139,7 @@ void SeekPlayhead(double seconds);
 void SnapPlayhead();
 void DetectPlayheadLimits();
 void FitZoomWholeTimeline();
+float CalculateDynamicHeight();
 std::string FormattedStringFromTime(otio::RationalTime time, bool allow_rate = true);
 std::string TimecodeStringFromTime(otio::RationalTime);
 std::string FramesStringFromTime(otio::RationalTime);

--- a/timeline.cpp
+++ b/timeline.cpp
@@ -887,6 +887,17 @@ bool DrawTimecodeTrack(
     bool interactive = true) {
     bool moved_playhead = false;
 
+    // Adjust track_height based on the number of visible elements
+    const float baseHeight = 25.0f; // Base height of one element
+    int visibleElementCount = 0;
+    if (appState.display_timecode) visibleElementCount++;
+    if (appState.display_frames) visibleElementCount++;
+    if (appState.display_seconds) visibleElementCount++;
+    if (appState.display_rate) visibleElementCount++;
+
+    // Calculate the new track height
+    track_height = baseHeight * visibleElementCount;
+
     float width = ImGui::GetContentRegionAvail().x;
     ImVec2 size(fmaxf(full_width, width), track_height);
 

--- a/timeline.cpp
+++ b/timeline.cpp
@@ -888,15 +888,7 @@ bool DrawTimecodeTrack(
     bool moved_playhead = false;
 
     // Adjust track_height based on the number of visible elements
-    const float baseHeight = 25.0f; // Base height of one element
-    int visibleElementCount = 0;
-    if (appState.display_timecode) visibleElementCount++;
-    if (appState.display_frames) visibleElementCount++;
-    if (appState.display_seconds) visibleElementCount++;
-    if (appState.display_rate) visibleElementCount++;
-
-    // Calculate the new track height
-    track_height = baseHeight * visibleElementCount;
+    track_height = CalculateDynamicHeight();
 
     float width = ImGui::GetContentRegionAvail().x;
     ImVec2 size(fmaxf(full_width, width), track_height);


### PR DESCRIPTION
My first pull request - and very much not an experienced coder - so apologies if incorrect etiquette. (e.g. I can't figure out how to get the .gitignore update to be ignored...)

I found it a little annoying that adding to the timecode displays did not dynamically adjust the timecode track height. Just made a minor change to timeline.cpp around line 883.

**BEFORE**
![Otio_raven-timecode display height 2-after](https://github.com/user-attachments/assets/0107a2c0-8c8e-489d-88e6-70ad9fb36d4d)

**AFTER**
![Otio_raven-timecode display height 1-before](https://github.com/user-attachments/assets/84cbbc65-7eca-49c2-b3e5-c384fd8730cd)

