### PR TITLE
Add drag and drop support for Windows

### DIFF
--- a/main_win32.cpp
+++ b/main_win32.cpp
@@ -304,14 +304,20 @@ LRESULT WINAPI WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
         UINT count = DragQueryFileA(hDrop, -1, NULL, 0);
 
         char** file_list;
-        file_list = (char**)malloc(count * sizeof(char*));
-        char temp_filename[MAX_PATH];
+        file_list = (char**)malloc(count * sizeof(wchar_t*));
+        wchar_t temp_filename[MAX_PATH];
 
         for(UINT i = 0; i < count; ++i)
         {
-           if (DragQueryFileA(hDrop, i, temp_filename, MAX_PATH))
-               file_list[i] = (char*)malloc(MAX_PATH * sizeof(char));
-               strcpy_s(file_list[i],MAX_PATH, temp_filename);
+           if (DragQueryFileW(hDrop, i, temp_filename, MAX_PATH))
+           {
+                // Determine the required buffer size for the multi-byte string
+                int buffer_size = WideCharToMultiByte(CP_UTF8, 0, temp_filename, -1, NULL, 0, NULL, NULL);
+                file_list[i] = (char*)malloc(buffer_size * sizeof(char));
+
+                // Convert wide character filename to UTF-8
+                WideCharToMultiByte(CP_UTF8, 0, temp_filename, -1, file_list[i], buffer_size, NULL, NULL);
+           }
         }
 
         DragFinish(hDrop);

--- a/main_win32.cpp
+++ b/main_win32.cpp
@@ -304,7 +304,7 @@ LRESULT WINAPI WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
         UINT count = DragQueryFileA(hDrop, -1, NULL, 0);
 
         char** file_list;
-        file_list = (char**)malloc(count * sizeof(wchar_t*));
+        file_list = (char**)malloc(count * sizeof(char*));
         wchar_t temp_filename[MAX_PATH];
 
         for(UINT i = 0; i < count; ++i)

--- a/main_win32.cpp
+++ b/main_win32.cpp
@@ -302,7 +302,7 @@ LRESULT WINAPI WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
         break;
     case WM_DROPFILES:
         HDROP hDrop = reinterpret_cast<HDROP>(wParam);
-        UINT count = DragQueryFileA(hDrop, -1, NULL, 0);
+        UINT count = DragQueryFileW(hDrop, -1, NULL, 0);
 
         char** file_list;
         file_list = (char**)malloc(count * sizeof(char*));

--- a/main_win32.cpp
+++ b/main_win32.cpp
@@ -8,6 +8,7 @@
 #include <d3d11.h>
 #include <shellapi.h>
 #include <tchar.h>
+#include <stdio.h>
 
 #include "main.h"
 
@@ -309,15 +310,15 @@ LRESULT WINAPI WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
 
         for(UINT i = 0; i < count; ++i)
         {
-           if (DragQueryFileW(hDrop, i, temp_filename, MAX_PATH))
-           {
+            if (DragQueryFileW(hDrop, i, temp_filename, MAX_PATH))
+            {
                 // Determine the required buffer size for the multi-byte string
                 int buffer_size = WideCharToMultiByte(CP_UTF8, 0, temp_filename, -1, NULL, 0, NULL, NULL);
                 file_list[i] = (char*)malloc(buffer_size * sizeof(char));
 
                 // Convert wide character filename to UTF-8
                 WideCharToMultiByte(CP_UTF8, 0, temp_filename, -1, file_list[i], buffer_size, NULL, NULL);
-           }
+            }
         }
 
         DragFinish(hDrop);


### PR DESCRIPTION
As per #57 I've added drag and drop support for Windows. It seems to work okay on basic testing but I'm always a bit iffy about C pointers so please let me know if I've messed something up there.

If you drag a single file it loads correctly but if you drag several it triggers the existing code path for loading multiple files so any changes to that should work as expected on Windows