### PR TITLE
None timeline load

### DIFF
--- a/app.cpp
+++ b/app.cpp
@@ -20,6 +20,8 @@
 #include <chrono>
 #include <iostream>
 
+#include <opentimelineio/clip.h>
+
 void DrawMenu();
 void DrawToolbar(ImVec2 buttonSize);
 void DrawDroppedFilesPrompt();
@@ -289,7 +291,14 @@ void LoadFile(std::string path) {
         auto timeline = dynamic_cast<otio::Timeline*>(root);
         LoadTimeline(timeline);
         file_name = timeline->name();
-    } else {
+    } else if (root->schema_name() == "Clip") {
+        auto clip = dynamic_cast<otio::Clip*>(root);
+        file_name = clip->name();
+
+        auto timeline = new otio::Timeline();
+        LoadTimeline(timeline);
+        SelectObject(clip);
+    } else{
         Message(
             "Error loading \"%s\": Unsupported root schema: %s",
             path.c_str(),
@@ -900,7 +909,7 @@ void SelectObject(
         appState.selected_text = "No selection";
     } else {
         otio::ErrorStatus error_status;
-        appState.selected_text = object->to_json_string(&error_status);
+        //appState.selected_text = object->to_json_string(&error_status);
         if (otio::is_error(error_status)) {
             appState.selected_text = otio_error_string(error_status);
         }

--- a/app.h
+++ b/app.h
@@ -83,7 +83,7 @@ struct AppState {
 
     // This holds the main timeline object.
     // Pretty much everything drills into this one entry point.
-    otio::SerializableObject::Retainer<otio::Timeline> timeline;
+    otio::SerializableObjectWithMetadata* root;
 
     // Timeline display settings
     float timeline_width = 100.0f; // automatically calculated (pixels)

--- a/editing.cpp
+++ b/editing.cpp
@@ -8,8 +8,8 @@
 #include <stdlib.h>
 
 void DeleteSelectedObject() {
-    if (appState.selected_object == appState.timeline) {
-        appState.timeline = NULL;
+    if (appState.selected_object == appState.root) {
+        appState.root = NULL;
         SelectObject(NULL);
         return;
     }
@@ -57,10 +57,16 @@ void DeleteSelectedObject() {
 
 void AddMarkerAtPlayhead(otio::Item* item, std::string name, std::string color) {
     auto playhead = appState.playhead;
-
-    const auto& timeline = appState.timeline;
-    if (!timeline)
+    
+    
+    if (!appState.root)
         return;
+
+    if (appState.root->schema_name() != "Timeline"){
+        return;
+    }
+
+    const auto& timeline = dynamic_cast<otio::Timeline*>(appState.root);
 
     // Default to the selected item, or the top-level timeline.
     if (item == NULL) {
@@ -91,9 +97,14 @@ void AddMarkerAtPlayhead(otio::Item* item, std::string name, std::string color) 
 }
 
 void AddTrack(std::string kind) {
-    const auto& timeline = appState.timeline;
-    if (!timeline)
+    if (!appState.root)
         return;
+
+    if (appState.root->schema_name() != "Timeline"){
+        return;
+    }
+
+    const auto& timeline = dynamic_cast<otio::Timeline*>(appState.root);
 
     // Fall back to the top level stack.
     int insertion_index = -1;
@@ -150,7 +161,7 @@ void AddTrack(std::string kind) {
 }
 
 void FlattenTrackDown() {
-    const auto& timeline = appState.timeline;
+    const auto& timeline = appState.root;
     if (!timeline) {
         Message("Cannot flatten: No timeline.");
         return;

--- a/inspector.cpp
+++ b/inspector.cpp
@@ -616,20 +616,27 @@ void DrawMarkersInspector() {
     typedef std::pair<otio::SerializableObject::Retainer<otio::Marker>, otio::SerializableObject::Retainer<otio::Item>> marker_parent_pair;
     std::vector<marker_parent_pair> pairs;
 
-    auto root = appState.timeline->tracks();
-    auto global_start = appState.timeline->global_start_time().value_or(otio::RationalTime());
+    auto root = new otio::Stack();
+    auto global_start = otio::RationalTime(0.0);
 
-    for (const auto& marker : root->markers()) {
-        pairs.push_back(marker_parent_pair(marker, root));
-    }
+    if (appState.root->schema_name() == "Timeline"){
+        const auto& timeline = dynamic_cast<otio::Timeline*>(appState.root);
 
-    for (const auto& child :
-         appState.timeline->tracks()->find_children())
-    {
-        if (const auto& item = dynamic_cast<otio::Item*>(&*child))
+        root = timeline->tracks();
+        global_start = timeline->global_start_time().value_or(otio::RationalTime());
+
+        for (const auto& marker : root->markers()) {
+            pairs.push_back(marker_parent_pair(marker, root));
+        }
+
+        for (const auto& child :
+            timeline->tracks()->find_children())
         {
-            for (const auto& marker : item->markers()) {
-                pairs.push_back(marker_parent_pair(marker, item));
+            if (const auto& item = dynamic_cast<otio::Item*>(&*child))
+            {
+                for (const auto& marker : item->markers()) {
+                    pairs.push_back(marker_parent_pair(marker, item));
+                }
             }
         }
     }
@@ -714,20 +721,27 @@ void DrawEffectsInspector() {
     typedef std::pair<otio::SerializableObject::Retainer<otio::Effect>, otio::SerializableObject::Retainer<otio::Item>> effect_parent_pair;
     std::vector<effect_parent_pair> pairs;
 
-    auto root = appState.timeline->tracks();
-    auto global_start = appState.timeline->global_start_time().value_or(otio::RationalTime());
+    auto root = new otio::Stack();
+    auto global_start = otio::RationalTime(0.0);
 
-    for (const auto& effect : root->effects()) {
-        pairs.push_back(effect_parent_pair(effect, root));
-    }
+    if (appState.root->schema_name() == "Timeline"){
+        const auto& timeline = dynamic_cast<otio::Timeline*>(appState.root);
 
-    for (const auto& child :
-         appState.timeline->tracks()->find_children())
-    {
-        if (const auto& item = dynamic_cast<otio::Item*>(&*child))
+        root = timeline->tracks();
+        global_start = timeline->global_start_time().value_or(otio::RationalTime());
+
+        for (const auto& effect : root->effects()) {
+            pairs.push_back(effect_parent_pair(effect, root));
+        }
+
+        for (const auto& child :
+            timeline->tracks()->find_children())
         {
-            for (const auto& effect : item->effects()) {
-                pairs.push_back(effect_parent_pair(effect, item));
+            if (const auto& item = dynamic_cast<otio::Item*>(&*child))
+            {
+                for (const auto& effect : item->effects()) {
+                    pairs.push_back(effect_parent_pair(effect, item));
+                }
             }
         }
     }

--- a/timeline.cpp
+++ b/timeline.cpp
@@ -46,7 +46,7 @@ void TopLevelTimeRangeMap(
     std::map<otio::Composable*, otio::TimeRange>& range_map,
     otio::Item* context) {
     auto zero = otio::RationalTime();
-    auto top = appState.timeline->tracks();
+    auto top = dynamic_cast<otio::Timeline*>(appState.root)->tracks();
     auto offset = context->transformed_time(zero, top);
 
     for (auto& pair : range_map) {


### PR DESCRIPTION
I made a start at #23 and I've managed to (I think) sensibly handle none `Timeline` schemas. I started looking at suppporting just clips and had a couple of questions:

1. Is this the right sort of approach?
2. For some reason `app.cpp:912` was causing the `selected_object` state to be cleared leading to crashes. Commenting it out fixes the issue but I can't figure out why it's happening in the first place.  

This is very much still a WIP but I wanted to check it was heading in the right direction before I go any further.

![image](https://github.com/user-attachments/assets/89ba1388-369a-4862-9073-c4044fd39572)
