### PR TITLE
Timeline arrow key navigation

### DIFF
--- a/app.h
+++ b/app.h
@@ -92,6 +92,8 @@ struct AppState {
     float track_height = 30.0f; // current track height (pixels)
     otio::RationalTime playhead;
     bool scroll_to_playhead = false; // temporary flag, only true until next frame
+    bool scroll_left = false; // temporary flag, only true until next frame
+    bool scroll_right = false; // temporary flag, only true until next frame
     otio::TimeRange
         playhead_limit; // min/max limit for moving the playhead, auto-calculated
     float zebra_factor = 0.1; // opacity of the per-frame zebra stripes

--- a/app.h
+++ b/app.h
@@ -92,8 +92,8 @@ struct AppState {
     float track_height = 30.0f; // current track height (pixels)
     otio::RationalTime playhead;
     bool scroll_to_playhead = false; // temporary flag, only true until next frame
-    bool scroll_left = false; // temporary flag, only true until next frame
-    bool scroll_right = false; // temporary flag, only true until next frame
+    bool scroll_key = false; // temporary flag, only true until next frame
+    bool scroll_up_down; // temporary flag, only true until next frame
     otio::TimeRange
         playhead_limit; // min/max limit for moving the playhead, auto-calculated
     float zebra_factor = 0.1; // opacity of the per-frame zebra stripes

--- a/main_glfw.cpp
+++ b/main_glfw.cpp
@@ -121,7 +121,7 @@ int main(int argc, char** argv)
     ImGui::CreateContext();
     ImPlot::CreateContext();
     ImGuiIO& io = ImGui::GetIO(); (void)io;
-    io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard;       // Enable Keyboard Controls
+    //io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard;       // Enable Keyboard Controls
     //io.ConfigFlags |= ImGuiConfigFlags_NavEnableGamepad;      // Enable Gamepad Controls
     io.ConfigFlags |= ImGuiConfigFlags_DockingEnable;           // Enable Docking
     io.ConfigFlags |= ImGuiConfigFlags_ViewportsEnable;         // Enable Multi-Viewport / Platform Windows

--- a/main_win32.cpp
+++ b/main_win32.cpp
@@ -104,7 +104,7 @@ int main(int argc, char** argv)
     ImGui::CreateContext();
     ImPlot::CreateContext();
     ImGuiIO& io = ImGui::GetIO(); (void)io;
-    io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard;       // Enable Keyboard Controls
+    //io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard;       // Enable Keyboard Controls
     //io.ConfigFlags |= ImGuiConfigFlags_NavEnableGamepad;      // Enable Gamepad Controls
     io.ConfigFlags |= ImGuiConfigFlags_DockingEnable;           // Enable Docking
     io.ConfigFlags |= ImGuiConfigFlags_ViewportsEnable;         // Enable Multi-Viewport / Platform Windows

--- a/timeline.cpp
+++ b/timeline.cpp
@@ -1540,83 +1540,87 @@ void DrawTimeline(otio::Timeline* timeline) {
             appState.scroll_to_playhead = false;
         }
 
-        if (ImGui::IsKeyPressed(ImGuiKey::ImGuiKey_RightArrow)) {
-            std::string selected_type = appState.selected_object->schema_name();
-            if (selected_type == "Clip" || selected_type == "Gap" || selected_type == "Transition") {
-                // Loop through selected items parent track to find the next item
-                auto parent = dynamic_cast<otio::Composable*>(appState.selected_object)->parent();
-                for(auto it = parent->children().begin(); it != parent->children().end(); it++ ){
-                    // If last item then do nothing
-                    if (std::next(it) == parent->children().end()) {
-                        break;
-                    }
-                    if (*it == appState.selected_object) {
-                        std::advance(it, 1);
-                        SelectObject(*it);
-                        appState.scroll_right = true;
-                        break;
-                    }
-                }
-            }
-        }
-
-        if (ImGui::IsKeyPressed(ImGuiKey::ImGuiKey_LeftArrow)) {
-            std::string selected_type = appState.selected_object->schema_name();
-            if (selected_type == "Clip" || selected_type == "Gap" || selected_type == "Transition") {
-                // Loop through selected items parent track to find the previous item
-                auto parent = dynamic_cast<otio::Composable*>(appState.selected_object)->parent();
-                for(auto it = parent->children().begin(); it != parent->children().end(); it++ ){
-                    if (*it == appState.selected_object) {
-                        // If first item do nothing
-                        if (it == parent->children().begin()) {
-                            break;
-                        }
-                        std::advance(it, -1);
-                        SelectObject(*it);
-                        appState.scroll_left = true;
-                        break;
-                    }
-                }
-            }
-        }
-
-        if (ImGui::IsKeyPressed(ImGuiKey::ImGuiKey_UpArrow)) {
-            std::string selected_type = appState.selected_object->schema_name();
-            if (selected_type == "Clip" || selected_type == "Gap" || selected_type == "Transition") {
-                // Finding start time varies depending on object type
-                otio::RationalTime start_time;
-                if (selected_type == "Clip" || selected_type == "Gap") {
-                    auto child = dynamic_cast<otio::Item*>(appState.selected_object);
-                    start_time = child->range_in_parent().start_time();
-                } else if (selected_type == "Transition") {
-                    auto child = dynamic_cast<otio::Transition*>(appState.selected_object);
-                    start_time = child->range_in_parent().value().start_time();
-                }
-
-                auto parent = dynamic_cast<otio::Composable*>(appState.selected_object)->parent();
-                auto tracks = dynamic_cast<otio::Stack*>(parent->parent());
-
-                // Loop through tracks until we find the current one
-                for(auto it = tracks->children().begin(); it != tracks->children().end(); it++ ){
-                    otio::Composable* track = *it;
-                    if (track == parent) {
+        if (ImGui::IsWindowFocused()){
+            // Right arrow
+            if (ImGui::IsKeyPressed(ImGuiKey::ImGuiKey_RightArrow)) {
+                std::string selected_type = appState.selected_object->schema_name();
+                if (selected_type == "Clip" || selected_type == "Gap" || selected_type == "Transition") {
+                    // Loop through selected items parent track to find the next item
+                    auto parent = dynamic_cast<otio::Composable*>(appState.selected_object)->parent();
+                    for(auto it = parent->children().begin(); it != parent->children().end(); it++ ){
                         // If last item then do nothing
-                        if (std::next(it) == tracks->children().end()) {
+                        if (std::next(it) == parent->children().end()) {
                             break;
                         }
-                        // Select the next track up
-                        std::advance(it, 1);
-                        otio::Composable* next_track = *it;
-
-                        // If there is an iten that overlaps with the current selection start time
-                        // select it
-                        if (dynamic_cast<otio::Track*>(next_track)->child_at_time(start_time)){
-                            SelectObject(dynamic_cast<otio::Track*>(next_track)->child_at_time(start_time));
+                        if (*it == appState.selected_object) {
+                            std::advance(it, 1);
+                            SelectObject(*it);
+                            appState.scroll_right = true;
                             break;
                         }
                     }
                 }
             }
+            // Left Arrow
+            if (ImGui::IsKeyPressed(ImGuiKey::ImGuiKey_LeftArrow)) {
+                std::string selected_type = appState.selected_object->schema_name();
+                if (selected_type == "Clip" || selected_type == "Gap" || selected_type == "Transition") {
+                    // Loop through selected items parent track to find the previous item
+                    auto parent = dynamic_cast<otio::Composable*>(appState.selected_object)->parent();
+                    for(auto it = parent->children().begin(); it != parent->children().end(); it++ ){
+                        if (*it == appState.selected_object) {
+                            // If first item do nothing
+                            if (it == parent->children().begin()) {
+                                break;
+                            }
+                            std::advance(it, -1);
+                            SelectObject(*it);
+                            appState.scroll_left = true;
+                            break;
+                        }
+                    }
+                }
+            }
+            // Up Arrow
+            if (ImGui::IsKeyPressed(ImGuiKey::ImGuiKey_UpArrow)) {
+                std::string selected_type = appState.selected_object->schema_name();
+                if (selected_type == "Clip" || selected_type == "Gap" || selected_type == "Transition") {
+                    // Finding start time varies depending on object type
+                    otio::RationalTime start_time;
+                    if (selected_type == "Clip" || selected_type == "Gap") {
+                        auto child = dynamic_cast<otio::Item*>(appState.selected_object);
+                        start_time = child->range_in_parent().start_time();
+                    } else if (selected_type == "Transition") {
+                        auto child = dynamic_cast<otio::Transition*>(appState.selected_object);
+                        start_time = child->range_in_parent().value().start_time();
+                    }
+
+                    auto parent = dynamic_cast<otio::Composable*>(appState.selected_object)->parent();
+                    auto tracks = dynamic_cast<otio::Stack*>(parent->parent());
+
+                    // Loop through tracks until we find the current one
+                    for(auto it = tracks->children().begin(); it != tracks->children().end(); it++ ){
+                        otio::Composable* track = *it;
+                        if (track == parent) {
+                            // If last item then do nothing
+                            if (std::next(it) == tracks->children().end()) {
+                                break;
+                            }
+                            // Select the next track up
+                            std::advance(it, 1);
+                            otio::Composable* next_track = *it;
+
+                            // If there is an iten that overlaps with the current selection start time
+                            // select it
+                            if (dynamic_cast<otio::Track*>(next_track)->child_at_time(start_time)){
+                                SelectObject(dynamic_cast<otio::Track*>(next_track)->child_at_time(start_time));
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+
         }
 
         // This is helpful when debugging visibility performance optimization

--- a/timeline.cpp
+++ b/timeline.cpp
@@ -1393,9 +1393,7 @@ void HandleKeyboardNavigation() {
 
                         if (tracks){
                             // Loop through tracks until we find the current one
-                            int track_count = 0;
                             for(auto it = tracks->children().begin(); it != tracks->children().end(); it++ ){
-                                track_count++;
                                 otio::Composable* track = *it;
                                 if (track == parent) {
                                     // Down Arrow and Video or Up Arrow and Audio

--- a/timeline.cpp
+++ b/timeline.cpp
@@ -1540,43 +1540,48 @@ void DrawTimeline(otio::Timeline* timeline) {
             appState.scroll_to_playhead = false;
         }
 
+        // selected_item is used by both left and right key logic
+        auto selected_item = dynamic_cast<otio::Composable*>(appState.selected_object);
+
         if (ImGui::IsWindowFocused()){
             // Right arrow
             if (ImGui::IsKeyPressed(ImGuiKey::ImGuiKey_RightArrow)) {
-                std::string selected_type = appState.selected_object->schema_name();
-                if (selected_type == "Clip" || selected_type == "Gap" || selected_type == "Transition") {
+                if (selected_item) {
                     // Loop through selected items parent track to find the next item
-                    auto parent = dynamic_cast<otio::Composable*>(appState.selected_object)->parent();
-                    for(auto it = parent->children().begin(); it != parent->children().end(); it++ ){
-                        // If last item then do nothing
-                        if (std::next(it) == parent->children().end()) {
-                            break;
-                        }
-                        if (*it == appState.selected_object) {
-                            std::advance(it, 1);
-                            SelectObject(*it);
-                            appState.scroll_right = true;
-                            break;
+                    auto parent = selected_item->parent();
+                    if (parent && parent->schema_name() == "Track"){
+                        for(auto it = parent->children().begin(); it != parent->children().end(); it++ ){
+                            // If last item then do nothing
+                            if (std::next(it) == parent->children().end()) {
+                                break;
+                            }
+                            if (*it == appState.selected_object) {
+                                std::advance(it, 1);
+                                SelectObject(*it);
+                                appState.scroll_right = true;
+                                break;
+                            }
                         }
                     }
                 }
             }
             // Left Arrow
             if (ImGui::IsKeyPressed(ImGuiKey::ImGuiKey_LeftArrow)) {
-                std::string selected_type = appState.selected_object->schema_name();
-                if (selected_type == "Clip" || selected_type == "Gap" || selected_type == "Transition") {
+                if (selected_item){
                     // Loop through selected items parent track to find the previous item
-                    auto parent = dynamic_cast<otio::Composable*>(appState.selected_object)->parent();
-                    for(auto it = parent->children().begin(); it != parent->children().end(); it++ ){
-                        if (*it == appState.selected_object) {
-                            // If first item do nothing
-                            if (it == parent->children().begin()) {
+                    auto parent = selected_item->parent();
+                    if (parent && parent->schema_name() =="Track"){
+                        for(auto it = parent->children().begin(); it != parent->children().end(); it++ ){
+                            if (*it == appState.selected_object) {
+                                // If first item do nothing
+                                if (it == parent->children().begin()) {
+                                    break;
+                                }
+                                std::advance(it, -1);
+                                SelectObject(*it);
+                                appState.scroll_left = true;
                                 break;
                             }
-                            std::advance(it, -1);
-                            SelectObject(*it);
-                            appState.scroll_left = true;
-                            break;
                         }
                     }
                 }
@@ -1585,78 +1590,70 @@ void DrawTimeline(otio::Timeline* timeline) {
             // The Stacks of video and audio Tracks go in opposite directions
             // therefore the logic for the for the Up Arrow on Video tracks is
             // the same as the logic for Down Arrow on Audio tracks and vice versa
+            if (selected_item && selected_item->parent()){
+                auto parent = selected_item->parent();
+                auto selected_track = dynamic_cast<otio::Track*>(parent);
+                if (selected_track){
+                    std::string selected_track_type = selected_track->kind();
 
-            auto parent = dynamic_cast<otio::Composable*>(appState.selected_object)->parent();
-            auto selected_track = dynamic_cast<otio::Track*>(parent);
-            std::string selected_track_type = selected_track->kind();
+                    if ((ImGui::IsKeyPressed(ImGuiKey::ImGuiKey_DownArrow)) ||
+                        (ImGui::IsKeyPressed(ImGuiKey::ImGuiKey_UpArrow))) {
 
-             if ((ImGui::IsKeyPressed(ImGuiKey::ImGuiKey_DownArrow)) ||
-                (ImGui::IsKeyPressed(ImGuiKey::ImGuiKey_UpArrow))) {
+                        // Only run if the right type is selected
+                        std::string selected_type = appState.selected_object->schema_name();
+                        if (selected_type == "Clip" || selected_type == "Gap" || selected_type == "Transition") {
+                            otio::RationalTime start_time = parent->range_of_child(selected_item).start_time();
+                            auto tracks = dynamic_cast<otio::Stack*>(parent->parent());
 
-                // Only run if the right type is selected
-                std::string selected_type = appState.selected_object->schema_name();
-                if (selected_type == "Clip" || selected_type == "Gap" || selected_type == "Transition") {
+                            if (tracks){
+                                // Loop through tracks until we find the current one
+                                for(auto it = tracks->children().begin(); it != tracks->children().end(); it++ ){
+                                    otio::Composable* track = *it;
+                                    if (track == parent) {
+                                        // Down Arrow and Video or Up Arrow and Audio
+                                        if ((ImGui::IsKeyPressed(ImGuiKey::ImGuiKey_DownArrow) && selected_track_type == "Video") ||
+                                            (ImGui::IsKeyPressed(ImGuiKey::ImGuiKey_UpArrow) && selected_track_type == "Audio")) {
+                                            // If first item then do nothing
+                                            if (it == tracks->children().begin()) {
+                                                break;
+                                            }
+                                            // Select the next track up
+                                            std::advance(it, -1);
 
-                    // Finding start time varies depending on object type
-                    otio::RationalTime start_time;
-                    if (selected_type == "Clip" || selected_type == "Gap") {
-                        auto child = dynamic_cast<otio::Item*>(appState.selected_object);
-                        start_time = child->range_in_parent().start_time();
-                    } else if (selected_type == "Transition") {
-                        auto child = dynamic_cast<otio::Transition*>(appState.selected_object);
-                        start_time = child->range_in_parent().value().start_time();
-                    }
+                                        // Up Arrow and Video or Down Arrow and Audio
+                                        } else if ((ImGui::IsKeyPressed(ImGuiKey::ImGuiKey_UpArrow) && selected_track_type == "Video") ||
+                                                (ImGui::IsKeyPressed(ImGuiKey::ImGuiKey_DownArrow) && selected_track_type == "Audio")) {
+                                            // If last item then do nothing
+                                            if (std::next(it) == tracks->children().end()) {
+                                                break;
+                                            }
+                                            // Select the next track up
+                                            std::advance(it, 1);
+                                        } else{
+                                            break;
+                                        }
 
-                    // Get the parent object and track stack
-                    auto parent = dynamic_cast<otio::Composable*>(appState.selected_object)->parent();
-                    auto tracks = dynamic_cast<otio::Stack*>(parent->parent());
+                                        otio::Composable* next_it = *it;
+                                        otio::Track* next_track = dynamic_cast<otio::Track*>(next_it);
 
-                    // Loop through tracks until we find the current one
-                    for(auto it = tracks->children().begin(); it != tracks->children().end(); it++ ){
-                        otio::Composable* track = *it;
-                        if (track == parent) {
-                            // Down Arrow and Video or Up Arrow and Audio
-                            if ((ImGui::IsKeyPressed(ImGuiKey::ImGuiKey_DownArrow) && selected_track_type == "Video") ||
-                                (ImGui::IsKeyPressed(ImGuiKey::ImGuiKey_UpArrow) && selected_track_type == "Audio")) {
-                                // If first item then do nothing
-                                if (it == tracks->children().begin()) {
-                                    break;
+                                        // Only iterate over tracks of the same kind
+                                        if(next_track->kind() != selected_track_type){
+                                            break;
+                                        }
+
+                                        // If there is an iten that overlaps with the current selection's start time
+                                        // select it
+                                        if (next_track->child_at_time(start_time)){
+                                            SelectObject(next_track->child_at_time(start_time));
+                                            break;
+                                        }
+                                    }
                                 }
-                                // Select the next track up
-                                std::advance(it, -1);
-
-                            // Up Arrow and Video or Down Arrow and Audio
-                            } else if ((ImGui::IsKeyPressed(ImGuiKey::ImGuiKey_UpArrow) && selected_track_type == "Video") ||
-                                       (ImGui::IsKeyPressed(ImGuiKey::ImGuiKey_DownArrow) && selected_track_type == "Audio")) {
-                                // If last item then do nothing
-                                if (std::next(it) == tracks->children().end()) {
-                                    break;
-                                }
-                                // Select the next track up
-                                std::advance(it, 1);
-                            } else{
-                                break;
-                            }
-
-                            otio::Composable* next_it = *it;
-                            otio::Track* next_track = dynamic_cast<otio::Track*>(next_it);
-
-                            // Only iterate over tracks of the same kind
-                            if(next_track->kind() != selected_track_type){
-                                break;
-                            }
-
-                            // If there is an iten that overlaps with the current selection's start time
-                            // select it
-                            if (next_track->child_at_time(start_time)){
-                                SelectObject(next_track->child_at_time(start_time));
-                                break;
                             }
                         }
                     }
                 }
             }
-
         }
 
         // This is helpful when debugging visibility performance optimization

--- a/timeline.cpp
+++ b/timeline.cpp
@@ -1581,8 +1581,11 @@ void DrawTimeline(otio::Timeline* timeline) {
                     }
                 }
             }
-            // Up Arrow
-            if (ImGui::IsKeyPressed(ImGuiKey::ImGuiKey_UpArrow)) {
+            // Up arrow for Video tracks and down arrow for Audio tracks use the same logic
+            auto parent = dynamic_cast<otio::Composable*>(appState.selected_object)->parent();
+            auto selected_track = dynamic_cast<otio::Track*>(parent);
+            if ((ImGui::IsKeyPressed(ImGuiKey::ImGuiKey_UpArrow) && selected_track->kind() == "Video") ||
+                (ImGui::IsKeyPressed(ImGuiKey::ImGuiKey_DownArrow) && selected_track->kind() == "Audio")) {
                 std::string selected_type = appState.selected_object->schema_name();
                 if (selected_type == "Clip" || selected_type == "Gap" || selected_type == "Transition") {
                     // Finding start time varies depending on object type

--- a/timeline.cpp
+++ b/timeline.cpp
@@ -1581,11 +1581,16 @@ void DrawTimeline(otio::Timeline* timeline) {
                     }
                 }
             }
-            // Up arrow for Video tracks and down arrow for Audio tracks use the same logic
+            // The Stacks of video and audio Tracks go in opposite directions
+            // therefore the logic for the for the Up Arrow on Video tracks is
+            // the same as the logic for Down Arrow on Audio tracks and vice versa
+
             auto parent = dynamic_cast<otio::Composable*>(appState.selected_object)->parent();
             auto selected_track = dynamic_cast<otio::Track*>(parent);
-            if ((ImGui::IsKeyPressed(ImGuiKey::ImGuiKey_UpArrow) && selected_track->kind() == "Video") ||
-                (ImGui::IsKeyPressed(ImGuiKey::ImGuiKey_DownArrow) && selected_track->kind() == "Audio")) {
+            std::string selected_track_type = selected_track->kind();
+
+            if ((ImGui::IsKeyPressed(ImGuiKey::ImGuiKey_UpArrow) && selected_track_type == "Video") ||
+                (ImGui::IsKeyPressed(ImGuiKey::ImGuiKey_DownArrow) && selected_track_type == "Audio")) {
                 std::string selected_type = appState.selected_object->schema_name();
                 if (selected_type == "Clip" || selected_type == "Gap" || selected_type == "Transition") {
                     // Finding start time varies depending on object type
@@ -1611,12 +1616,64 @@ void DrawTimeline(otio::Timeline* timeline) {
                             }
                             // Select the next track up
                             std::advance(it, 1);
-                            otio::Composable* next_track = *it;
+                            otio::Composable* next_it = *it;
+                            otio::Track* next_track = dynamic_cast<otio::Track*>(next_it);
+
+                            // Only iterate over tracks of the same kind
+                            if(next_track->kind() != selected_track_type){
+                                break;
+                            }
 
                             // If there is an iten that overlaps with the current selection start time
                             // select it
-                            if (dynamic_cast<otio::Track*>(next_track)->child_at_time(start_time)){
-                                SelectObject(dynamic_cast<otio::Track*>(next_track)->child_at_time(start_time));
+                            if (next_track->child_at_time(start_time)){
+                                SelectObject(next_track->child_at_time(start_time));
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+
+             if ((ImGui::IsKeyPressed(ImGuiKey::ImGuiKey_DownArrow) && selected_track_type == "Video") ||
+                (ImGui::IsKeyPressed(ImGuiKey::ImGuiKey_UpArrow) && selected_track_type == "Audio")) {
+                std::string selected_type = appState.selected_object->schema_name();
+                if (selected_type == "Clip" || selected_type == "Gap" || selected_type == "Transition") {
+                    // Finding start time varies depending on object type
+                    otio::RationalTime start_time;
+                    if (selected_type == "Clip" || selected_type == "Gap") {
+                        auto child = dynamic_cast<otio::Item*>(appState.selected_object);
+                        start_time = child->range_in_parent().start_time();
+                    } else if (selected_type == "Transition") {
+                        auto child = dynamic_cast<otio::Transition*>(appState.selected_object);
+                        start_time = child->range_in_parent().value().start_time();
+                    }
+
+                    auto parent = dynamic_cast<otio::Composable*>(appState.selected_object)->parent();
+                    auto tracks = dynamic_cast<otio::Stack*>(parent->parent());
+
+                    // Loop through tracks until we find the current one
+                    for(auto it = tracks->children().begin(); it != tracks->children().end(); it++ ){
+                        otio::Composable* track = *it;
+                        if (track == parent) {
+                            // If last item then do nothing
+                            if (it == tracks->children().begin()) {
+                                break;
+                            }
+                            // Select the next track up
+                            std::advance(it, -1);
+                            otio::Composable* next_it = *it;
+                            otio::Track* next_track = dynamic_cast<otio::Track*>(next_it);
+
+                            // Only iterate over tracks of the same kind
+                            if(next_track->kind() != selected_track_type){
+                                break;
+                            }
+
+                            // If there is an iten that overlaps with the current selection start time
+                            // select it
+                            if (next_track->child_at_time(start_time)){
+                                SelectObject(next_track->child_at_time(start_time));
                                 break;
                             }
                         }


### PR DESCRIPTION
I mad a start on tackling #73 here and I think I made some decent progress. This currently adds support for using the left and right arrow keys to move around the timeline and change the selected item. It's a little clunky when moving off the edge of the visible workarea and I'd love some input on improving that. At the moment it jumps forwards or backwards by the size of the newly selected item.

I'm not entirely sure I've implemented the keyboard control in the most elegant way or put the code in the correct place in the code base, imeadiate mode GUIs are still new to me.  The other thing to note is it was necessary to disable the built in keyboard navigation to stop it conflicting 

with the new controls in odd ways. Is that okay? I think the way we're using a table here is not exactly how it was intended to be used. 

Fixes #73 

https://github.com/user-attachments/assets/94fe0148-d682-4758-9059-16b90d513da1