### PR TITLE
Don't build tests of third-party deps

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,7 @@ else()
   target_sources(raven PUBLIC main_glfw.cpp)
 endif()
 
+set(BUILD_TESTING OFF)
 add_subdirectory("libs")
 
 include_directories(


### PR DESCRIPTION
I noticed while building the project that third-party tests were being unnecessarily compiled. By Setting `BUILD_TESTING` to `OFF`, we reduce the number of compilation units by 24.