### PR TITLE
Improve responsiveness while maintaining power savings

### DIFF
--- a/main_glfw.cpp
+++ b/main_glfw.cpp
@@ -125,9 +125,6 @@ int main(int argc, char** argv)
     //io.ConfigFlags |= ImGuiConfigFlags_NavEnableGamepad;      // Enable Gamepad Controls
     io.ConfigFlags |= ImGuiConfigFlags_DockingEnable;           // Enable Docking
     io.ConfigFlags |= ImGuiConfigFlags_ViewportsEnable;         // Enable Multi-Viewport / Platform Windows
-#ifdef POWER_SAVING
-    io.ConfigFlags |= ImGuiConfigFlags_EnablePowerSavingMode;
-#endif
     io.ConfigViewportsNoAutoMerge = true;
     //io.ConfigViewportsNoTaskBarIcon = true;
 
@@ -166,27 +163,26 @@ int main(int argc, char** argv)
 
     ImVec4 clear_color = ImVec4(0.45f, 0.55f, 0.60f, 1.00f);
 
+    int cooldown_counter = 0;
+
     // Main loop
     while (!glfwWindowShouldClose(window))
     {
         // This application doesn't do any animation, so instead
         // of rendering all the time, we block waiting for events.
-        // The POWER_SAVING toggle is meant to be used with this
-        // fork of Dear ImGui: https://github.com/ocornut/imgui/pull/4076
-        // which would provide both the power savings, and support for
-        // animation, if we ever need/want to add animation to the app.
-        // See also: https://github.com/ocornut/imgui/pull/5599
-#ifdef POWER_SAVING
-        ImGui_ImplGlfw_WaitForEvent();
-#else
-        glfwWaitEvents();
-#endif
-        // Poll and handle events (inputs, window resize, etc.)
-        // You can read the io.WantCaptureMouse, io.WantCaptureKeyboard flags to tell if dear imgui wants to use your inputs.
-        // - When io.WantCaptureMouse is true, do not dispatch mouse input data to your main application.
-        // - When io.WantCaptureKeyboard is true, do not dispatch keyboard input data to your main application.
-        // Generally you may always pass all inputs to dear imgui, and hide them from your application based on those two flags.
-        glfwPollEvents();
+        // However, ImGui sometimes needs to render several frames
+        // in a row to fully handle an input event and it's follow-on
+        // effects (e.g. responding to a click which scrolls the timeline)
+        // so we use cooldown_counter to ensure at least 5 frames are
+        // rendered before we block again.
+        if (cooldown_counter <= 0) {
+            glfwWaitEvents();
+            cooldown_counter = 5;
+        }else{
+            // Poll and handle events (inputs, window resize, etc.)
+            glfwPollEvents();
+            cooldown_counter--;
+        }
 
         // Start the Dear ImGui frame
         ImGui_ImplOpenGL3_NewFrame();


### PR DESCRIPTION
Previously, Raven waited for input events before rendering. This prevented unnecessary rendering & power usage, but in some cases the app felt sluggish. Specifically, if you click on certain elements, the UI wouldn't fully refresh until you moved the mouse cursor which created mouse motion events that caused further render cycles. 

This PR uses a cooldown heuristic, as suggested by @meshula in #37, to ensure that at least 5 renders take place after waiting for events, but still allows the application to sleep waiting for events when truly idle.

Note: This PR only addresses the Linux and Mac builds. Applying this same technique for Windows should be possible, but I don't have a Windows computer to develop or test that code in `main_win32.cpp`.
