### PR TITLE
Tree inspector

### DIFF
--- a/app.cpp
+++ b/app.cpp
@@ -724,7 +724,7 @@ void MainGui() {
         ImGui::DockBuilderDockWindow("Inspector", dock_id_side);
         ImGui::DockBuilderDockWindow("JSON", dock_id_side);
         ImGui::DockBuilderDockWindow("Clips", dock_id_side);
-        ImGui::DockBuilderDockWindow("Composition Tree", dock_id_side);
+        ImGui::DockBuilderDockWindow("Tree", dock_id_side);
         ImGui::DockBuilderDockWindow("Markers", dock_id_side);
         ImGui::DockBuilderDockWindow("Effects", dock_id_side);
         ImGui::DockBuilderDockWindow("Settings", dock_id_side);
@@ -789,9 +789,9 @@ void MainGui() {
     ImGui::End();
 
     ImGui::SetNextWindowDockID(dockspace_id, ImGuiCond_FirstUseEver);
-    visible = ImGui::Begin("Composition Tree", NULL, window_flags);
+    visible = ImGui::Begin("Tree", NULL, window_flags);
     if (visible) {
-        DrawCompositionInspector();
+        DrawTreeInspector();
     }
     ImGui::End();
 

--- a/app.cpp
+++ b/app.cpp
@@ -780,6 +780,13 @@ void MainGui() {
     ImGui::End();
 
     ImGui::SetNextWindowDockID(dockspace_id, ImGuiCond_FirstUseEver);
+    visible = ImGui::Begin("Clips", NULL, window_flags);
+    if (visible) {
+        DrawClipsInspector();
+    }
+    ImGui::End();
+
+    ImGui::SetNextWindowDockID(dockspace_id, ImGuiCond_FirstUseEver);
     visible = ImGui::Begin("Markers", NULL, window_flags);
     if (visible) {
         DrawMarkersInspector();

--- a/app.cpp
+++ b/app.cpp
@@ -723,6 +723,8 @@ void MainGui() {
         ImGui::DockBuilderDockWindow("Timeline", dock_main_id);
         ImGui::DockBuilderDockWindow("Inspector", dock_id_side);
         ImGui::DockBuilderDockWindow("JSON", dock_id_side);
+        ImGui::DockBuilderDockWindow("Clips", dock_id_side);
+        ImGui::DockBuilderDockWindow("Composition Tree", dock_id_side);
         ImGui::DockBuilderDockWindow("Markers", dock_id_side);
         ImGui::DockBuilderDockWindow("Effects", dock_id_side);
         ImGui::DockBuilderDockWindow("Settings", dock_id_side);
@@ -783,6 +785,13 @@ void MainGui() {
     visible = ImGui::Begin("Clips", NULL, window_flags);
     if (visible) {
         DrawClipsInspector();
+    }
+    ImGui::End();
+
+    ImGui::SetNextWindowDockID(dockspace_id, ImGuiCond_FirstUseEver);
+    visible = ImGui::Begin("Composition Tree", NULL, window_flags);
+    if (visible) {
+        DrawCompositionInspector();
     }
     ImGui::End();
 

--- a/app.cpp
+++ b/app.cpp
@@ -723,7 +723,6 @@ void MainGui() {
         ImGui::DockBuilderDockWindow("Timeline", dock_main_id);
         ImGui::DockBuilderDockWindow("Inspector", dock_id_side);
         ImGui::DockBuilderDockWindow("JSON", dock_id_side);
-        ImGui::DockBuilderDockWindow("Clips", dock_id_side);
         ImGui::DockBuilderDockWindow("Tree", dock_id_side);
         ImGui::DockBuilderDockWindow("Markers", dock_id_side);
         ImGui::DockBuilderDockWindow("Effects", dock_id_side);
@@ -778,13 +777,6 @@ void MainGui() {
     visible = ImGui::Begin("JSON", NULL, window_flags);
     if (visible) {
         DrawJSONInspector();
-    }
-    ImGui::End();
-
-    ImGui::SetNextWindowDockID(dockspace_id, ImGuiCond_FirstUseEver);
-    visible = ImGui::Begin("Clips", NULL, window_flags);
-    if (visible) {
-        DrawClipsInspector();
     }
     ImGui::End();
 

--- a/inspector.cpp
+++ b/inspector.cpp
@@ -1007,6 +1007,18 @@ void DrawCompositionInspector() {
                 "%s", composable->name().c_str());
         }
 
+        if (ImGui::IsItemClicked()) {
+            if (parent == nullptr) {
+                appState.playhead = global_start;
+            } else {
+                auto t = parent->trimmed_range_of_child(composable)->start_time();
+                auto global_time = parent->transformed_time(t, root) + global_start;
+                appState.playhead = global_time;
+            }
+            SelectObject(composable);
+            appState.scroll_to_playhead = true;
+        }
+
         ImGui::TableNextColumn();
         ImGui::TextUnformatted(composable->schema_name().c_str());
 
@@ -1020,14 +1032,6 @@ void DrawCompositionInspector() {
 
         ImGui::TableNextColumn();
         ImGui::TextUnformatted(TimecodeStringFromTime(composable->duration()).c_str());
-
-        if (ImGui::IsItemClicked()) {
-            auto t = parent->trimmed_range_of_child(composable)->start_time();
-            auto global_time = parent->transformed_time(t, root) + global_start;
-            appState.playhead = global_time;
-            SelectObject(composable);
-            appState.scroll_to_playhead = true;
-        }
 
         if (open) {
             if (auto composition = dynamic_cast<otio::Composition*>(composable)) {

--- a/inspector.cpp
+++ b/inspector.cpp
@@ -984,7 +984,7 @@ void DrawClipsInspector() {
     ImGui::EndTable();
 }
 
-void DrawCompositionInspector() {
+void DrawTreeInspector() {
     auto root = appState.timeline->tracks();
     auto global_start = appState.timeline->global_start_time().value_or(otio::RationalTime());
 
@@ -1042,7 +1042,7 @@ void DrawCompositionInspector() {
         }
     };
 
-    if (ImGui::BeginTable("Composition",
+    if (ImGui::BeginTable("Tree",
                           4,
                           ImGuiTableFlags_NoSavedSettings |
                           ImGuiTableFlags_Resizable |

--- a/inspector.cpp
+++ b/inspector.cpp
@@ -973,8 +973,8 @@ void DrawClipsInspector() {
             auto global_time = clip->transformed_time(source_range->start_time(), root) + global_start;
             auto is_selected = (appState.selected_object == clip);
             if (ImGui::Selectable(TimecodeStringFromTime(global_time).c_str(), is_selected, selectable_flags)) {
-                appState.playhead = global_time;
                 SelectObject(clip);
+                appState.playhead = global_time;
                 appState.scroll_to_playhead = true;
             }
 

--- a/inspector.cpp
+++ b/inspector.cpp
@@ -985,11 +985,32 @@ void DrawClipsInspector() {
 }
 
 void DrawTreeInspector() {
+    enum FilterOptions {
+        All,
+        Clips,
+        Transitions,
+        Gaps
+    };
+
+    static const char* filter_options[] = { "All", "Clips", "Transitions", "Gaps" };
+    static FilterOptions current_filter = All;
+
+    ImGui::Combo("Filter", reinterpret_cast<int*>(&current_filter), filter_options, IM_ARRAYSIZE(filter_options));
+
     auto root = appState.timeline->tracks();
     auto global_start = appState.timeline->global_start_time().value_or(otio::RationalTime());
 
     std::function<void(otio::Composable*, otio::Composition*)> draw_composable;
     draw_composable = [&](otio::Composable* composable, otio::Composition* parent) {
+        bool is_leaf = dynamic_cast<otio::Composition*>(composable) == nullptr;
+
+        // Apply filter
+        if (is_leaf) {
+            if (current_filter == Clips && !dynamic_cast<otio::Clip*>(composable)) return;
+            if (current_filter == Transitions && !dynamic_cast<otio::Transition*>(composable)) return;
+            if (current_filter == Gaps && !dynamic_cast<otio::Gap*>(composable)) return;
+        }
+
         ImGui::TableNextRow();
         ImGui::TableNextColumn();
 

--- a/inspector.cpp
+++ b/inspector.cpp
@@ -1027,15 +1027,17 @@ void DrawTreeInspector() {
                 "%s", composable->name().c_str());
         }
 
+        otio::RationalTime global_time;
+        if (parent == nullptr) {
+            global_time = global_start;
+        } else {
+            auto t = parent->trimmed_range_of_child(composable)->start_time();
+            global_time = parent->transformed_time(t, root) + global_start;
+        }
+
         if (ImGui::IsItemClicked()) {
-            if (parent == nullptr) {
-                appState.playhead = global_start;
-            } else {
-                auto t = parent->trimmed_range_of_child(composable)->start_time();
-                auto global_time = parent->transformed_time(t, root) + global_start;
-                appState.playhead = global_time;
-            }
             SelectObject(composable);
+            appState.playhead = global_time;
             appState.scroll_to_playhead = true;
         }
 
@@ -1051,6 +1053,9 @@ void DrawTreeInspector() {
         }
 
         ImGui::TableNextColumn();
+        ImGui::TextUnformatted(TimecodeStringFromTime(global_time).c_str());
+
+        ImGui::TableNextColumn();
         ImGui::TextUnformatted(TimecodeStringFromTime(composable->duration()).c_str());
 
         if (open) {
@@ -1064,7 +1069,7 @@ void DrawTreeInspector() {
     };
 
     if (ImGui::BeginTable("Tree",
-                          4,
+                          5,
                           ImGuiTableFlags_NoSavedSettings |
                           ImGuiTableFlags_Resizable |
                           ImGuiTableFlags_Reorderable |
@@ -1072,6 +1077,7 @@ void DrawTreeInspector() {
         ImGui::TableSetupColumn("Name", ImGuiTableColumnFlags_WidthStretch);
         ImGui::TableSetupColumn("Type", ImGuiTableColumnFlags_WidthFixed);
         ImGui::TableSetupColumn("Start Time", ImGuiTableColumnFlags_WidthFixed);
+        ImGui::TableSetupColumn("Global Start Time", ImGuiTableColumnFlags_WidthFixed);
         ImGui::TableSetupColumn("Duration", ImGuiTableColumnFlags_WidthFixed);
 
         ImGui::TableHeadersRow();

--- a/inspector.cpp
+++ b/inspector.cpp
@@ -928,62 +928,6 @@ void DrawEffectsInspector() {
     ImGui::EndTable();
 }
 
-void DrawClipsInspector() {
-    std::vector<otio::SerializableObject::Retainer<otio::Clip>> clips;
-
-    auto root = appState.timeline->tracks();
-    auto global_start = appState.timeline->global_start_time().value_or(otio::RationalTime());
-
-    for (const auto& child : appState.timeline->tracks()->find_children()) {
-        if (const auto& clip = dynamic_cast<otio::Clip*>(&*child)) {
-            clips.push_back(clip);
-        }
-    }
-
-    auto selectable_flags = ImGuiSelectableFlags_SpanAllColumns | ImGuiSelectableFlags_AllowItemOverlap;
-
-    if (ImGui::BeginTable("Clips",
-                          3,
-                          ImGuiTableFlags_NoSavedSettings |
-                          ImGuiTableFlags_Resizable |
-                          ImGuiTableFlags_Reorderable |
-                          ImGuiTableFlags_Hideable)) {
-        ImGui::TableSetupColumn("Clip Name", ImGuiTableColumnFlags_WidthStretch);
-        ImGui::TableSetupColumn("Source Range", ImGuiTableColumnFlags_WidthStretch);
-        ImGui::TableSetupColumn("Global Start Time", ImGuiTableColumnFlags_WidthFixed);
-
-        ImGui::TableHeadersRow();
-
-        for (const auto& clip : clips) {
-
-            ImGui::PushID(clip.value);
-            ImGui::TableNextRow();
-
-            // Clip Name
-            ImGui::TableNextColumn();
-            ImGui::TextUnformatted(clip->name().c_str());
-
-            // Source Range
-            ImGui::TableNextColumn();
-            auto source_range = clip->source_range();
-            ImGui::TextUnformatted(TimecodeStringFromTime(source_range->start_time()).c_str());
-
-            // Global Start Time
-            ImGui::TableNextColumn();
-            auto global_time = clip->transformed_time(source_range->start_time(), root) + global_start;
-            auto is_selected = (appState.selected_object == clip);
-            if (ImGui::Selectable(TimecodeStringFromTime(global_time).c_str(), is_selected, selectable_flags)) {
-                SelectObject(clip);
-                appState.playhead = global_time;
-                appState.scroll_to_playhead = true;
-            }
-
-            ImGui::PopID();
-        }
-    }
-    ImGui::EndTable();
-}
-
 void DrawTreeInspector() {
     enum FilterOptions {
         All,

--- a/inspector.cpp
+++ b/inspector.cpp
@@ -1020,7 +1020,7 @@ void DrawTreeInspector() {
                           ImGuiTableFlags_Hideable)) {
         ImGui::TableSetupColumn("Name", ImGuiTableColumnFlags_WidthStretch);
         ImGui::TableSetupColumn("Type", ImGuiTableColumnFlags_WidthFixed);
-        ImGui::TableSetupColumn("Start Time", ImGuiTableColumnFlags_WidthFixed);
+        ImGui::TableSetupColumn("Start Time", ImGuiTableColumnFlags_WidthFixed | ImGuiTableColumnFlags_DefaultHide);
         ImGui::TableSetupColumn("Global Start Time", ImGuiTableColumnFlags_WidthFixed);
         ImGui::TableSetupColumn("Duration", ImGuiTableColumnFlags_WidthFixed);
 

--- a/inspector.cpp
+++ b/inspector.cpp
@@ -992,20 +992,20 @@ void DrawTreeInspector() {
             global_time = parent->transformed_time(t, tree_root) + global_start;
         }
 
-        bool is_selected = (appState.selected_object == composable);
-
-        if (ImGui::IsItemClicked()) {
-            SelectObject(composable);
-            appState.playhead = global_time;
-            appState.scroll_to_playhead = true;
-        }
-
+        // Highlight the row if the object is selected, or if it is the context object
+        // For example, if the selected object is a marker, the context object is the item containing that marker.
+        bool is_selected = (appState.selected_object == composable || appState.selected_context == composable);
         if (is_selected) {
             ImGui::TableSetBgColor(ImGuiTableBgTarget_RowBg0, ImGui::GetColorU32(ImGuiCol_Header));
         }
 
+        // The next column is the schema name
+        // We use that column to make the entire row selectable (via SpanAllColumns)
+        // instead of only the 1st column with the tree node.
         ImGui::TableNextColumn();
-        if (ImGui::Selectable(composable->schema_name().c_str(), is_selected, ImGuiSelectableFlags_SpanAllColumns | ImGuiSelectableFlags_AllowItemOverlap)) {
+        bool just_clicked = ImGui::IsItemClicked();
+        bool just_selected = ImGui::Selectable(composable->schema_name().c_str(), is_selected, ImGuiSelectableFlags_SpanAllColumns | ImGuiSelectableFlags_AllowItemOverlap);
+        if (just_clicked || just_selected) {
             SelectObject(composable);
             appState.playhead = global_time;
             appState.scroll_to_playhead = true;

--- a/inspector.cpp
+++ b/inspector.cpp
@@ -956,6 +956,8 @@ void DrawTreeInspector() {
         }
 
         ImGui::TableNextRow();
+        ImGui::PushID(composable);
+
         ImGui::TableNextColumn();
 
         bool open = false;
@@ -979,14 +981,24 @@ void DrawTreeInspector() {
             global_time = parent->transformed_time(t, root) + global_start;
         }
 
+        bool is_selected = (appState.selected_object == composable);
+
         if (ImGui::IsItemClicked()) {
             SelectObject(composable);
             appState.playhead = global_time;
             appState.scroll_to_playhead = true;
         }
 
+        if (is_selected) {
+            ImGui::TableSetBgColor(ImGuiTableBgTarget_RowBg0, ImGui::GetColorU32(ImGuiCol_Header));
+        }
+
         ImGui::TableNextColumn();
-        ImGui::TextUnformatted(composable->schema_name().c_str());
+        if (ImGui::Selectable(composable->schema_name().c_str(), is_selected, ImGuiSelectableFlags_SpanAllColumns | ImGuiSelectableFlags_AllowItemOverlap)) {
+            SelectObject(composable);
+            appState.playhead = global_time;
+            appState.scroll_to_playhead = true;
+        }
 
         ImGui::TableNextColumn();
         if (auto item = dynamic_cast<otio::Item*>(composable)) {

--- a/inspector.cpp
+++ b/inspector.cpp
@@ -988,11 +988,10 @@ void DrawCompositionInspector() {
     auto root = appState.timeline->tracks();
     auto global_start = appState.timeline->global_start_time().value_or(otio::RationalTime());
 
-    std::function<void(otio::Composable*, otio::Composition*, int)> draw_composable;
-    draw_composable = [&](otio::Composable* composable, otio::Composition* parent, int depth) {
+    std::function<void(otio::Composable*, otio::Composition*)> draw_composable;
+    draw_composable = [&](otio::Composable* composable, otio::Composition* parent) {
         ImGui::TableNextRow();
         ImGui::TableNextColumn();
-        ImGui::Indent(depth * ImGui::GetTreeNodeToLabelSpacing());
 
         bool open = false;
         if (auto composition = dynamic_cast<otio::Composition*>(composable)) {
@@ -1036,13 +1035,11 @@ void DrawCompositionInspector() {
         if (open) {
             if (auto composition = dynamic_cast<otio::Composition*>(composable)) {
                 for (const auto& child : composition->children()) {
-                    draw_composable(child, composition, depth + 1);
+                    draw_composable(child, composition);
                 }
             }
             ImGui::TreePop();
         }
-
-        ImGui::Unindent(depth * ImGui::GetTreeNodeToLabelSpacing());
     };
 
     if (ImGui::BeginTable("Composition",
@@ -1058,7 +1055,7 @@ void DrawCompositionInspector() {
 
         ImGui::TableHeadersRow();
 
-        draw_composable(root, nullptr, 0);
+        draw_composable(root, nullptr);
 
         ImGui::EndTable();
     }

--- a/inspector.cpp
+++ b/inspector.cpp
@@ -927,3 +927,59 @@ void DrawEffectsInspector() {
     }
     ImGui::EndTable();
 }
+
+void DrawClipsInspector() {
+    std::vector<otio::SerializableObject::Retainer<otio::Clip>> clips;
+
+    auto root = appState.timeline->tracks();
+    auto global_start = appState.timeline->global_start_time().value_or(otio::RationalTime());
+
+    for (const auto& child : appState.timeline->tracks()->find_children()) {
+        if (const auto& clip = dynamic_cast<otio::Clip*>(&*child)) {
+            clips.push_back(clip);
+        }
+    }
+
+    auto selectable_flags = ImGuiSelectableFlags_SpanAllColumns | ImGuiSelectableFlags_AllowItemOverlap;
+
+    if (ImGui::BeginTable("Clips",
+                          3,
+                          ImGuiTableFlags_NoSavedSettings |
+                          ImGuiTableFlags_Resizable |
+                          ImGuiTableFlags_Reorderable |
+                          ImGuiTableFlags_Hideable)) {
+        ImGui::TableSetupColumn("Clip Name", ImGuiTableColumnFlags_WidthStretch);
+        ImGui::TableSetupColumn("Source Range", ImGuiTableColumnFlags_WidthStretch);
+        ImGui::TableSetupColumn("Global Start Time", ImGuiTableColumnFlags_WidthFixed);
+
+        ImGui::TableHeadersRow();
+
+        for (const auto& clip : clips) {
+
+            ImGui::PushID(clip.value);
+            ImGui::TableNextRow();
+
+            // Clip Name
+            ImGui::TableNextColumn();
+            ImGui::TextUnformatted(clip->name().c_str());
+
+            // Source Range
+            ImGui::TableNextColumn();
+            auto source_range = clip->source_range();
+            ImGui::TextUnformatted(TimecodeStringFromTime(source_range->start_time()).c_str());
+
+            // Global Start Time
+            ImGui::TableNextColumn();
+            auto global_time = clip->transformed_time(source_range->start_time(), root) + global_start;
+            auto is_selected = (appState.selected_object == clip);
+            if (ImGui::Selectable(TimecodeStringFromTime(global_time).c_str(), is_selected, selectable_flags)) {
+                appState.playhead = global_time;
+                SelectObject(clip);
+                appState.scroll_to_playhead = true;
+            }
+
+            ImGui::PopID();
+        }
+    }
+    ImGui::EndTable();
+}

--- a/inspector.cpp
+++ b/inspector.cpp
@@ -1052,7 +1052,7 @@ void DrawCompositionInspector() {
                           ImGuiTableFlags_Reorderable |
                           ImGuiTableFlags_Hideable)) {
         ImGui::TableSetupColumn("Name", ImGuiTableColumnFlags_WidthStretch);
-        ImGui::TableSetupColumn("Type", ImGuiTableColumnFlags_WidthStretch);
+        ImGui::TableSetupColumn("Type", ImGuiTableColumnFlags_WidthFixed);
         ImGui::TableSetupColumn("Start Time", ImGuiTableColumnFlags_WidthFixed);
         ImGui::TableSetupColumn("Duration", ImGuiTableColumnFlags_WidthFixed);
 

--- a/inspector.h
+++ b/inspector.h
@@ -3,5 +3,6 @@
 void DrawInspector();
 void DrawJSONInspector();
 void DrawClipsInspector();
+void DrawCompositionInspector();
 void DrawMarkersInspector();
 void DrawEffectsInspector();

--- a/inspector.h
+++ b/inspector.h
@@ -2,7 +2,6 @@
 
 void DrawInspector();
 void DrawJSONInspector();
-void DrawClipsInspector();
 void DrawTreeInspector();
 void DrawMarkersInspector();
 void DrawEffectsInspector();

--- a/inspector.h
+++ b/inspector.h
@@ -2,5 +2,6 @@
 
 void DrawInspector();
 void DrawJSONInspector();
+void DrawClipsInspector();
 void DrawMarkersInspector();
 void DrawEffectsInspector();

--- a/inspector.h
+++ b/inspector.h
@@ -3,6 +3,6 @@
 void DrawInspector();
 void DrawJSONInspector();
 void DrawClipsInspector();
-void DrawCompositionInspector();
+void DrawTreeInspector();
 void DrawMarkersInspector();
 void DrawEffectsInspector();


### PR DESCRIPTION
This PR adds a new inspector tab "Tree" which shows a collapsable hierarchy matching the OTIO's composition structure.

Clicking on a row selects the corresponding object, and moves the playhead to that object's start time in the timeline. There is also a filter at the top to limit the tree to show only leaf nodes which are Clips, Transitions, or Gaps (or all).

See the bottom section of this screenshot:
![Screenshot 2025-02-14 at 6 04 05 PM](https://github.com/user-attachments/assets/c95a2b1e-3afd-4dd5-86a6-021e8c877276)
