### PR TITLE
Editable OTIO JSON inspector

### DIFF
--- a/app.h
+++ b/app.h
@@ -111,6 +111,7 @@ struct AppState {
     // objects which don't track their parent
     std::string selected_text; // displayed in the JSON inspector
     char message[1024]; // single-line message displayed in main window
+    bool message_is_error = false;
 
     // Toggles for Dear ImGui windows
     bool show_main_window = true;
@@ -126,6 +127,7 @@ extern ImFont* gFont;
 
 void Log(const char* format, ...);
 void Message(const char* format, ...);
+void ErrorMessage(const char* format, ...);
 std::string Format(const char* format, ...);
 
 void LoadString(std::string json);

--- a/editing.cpp
+++ b/editing.cpp
@@ -120,7 +120,7 @@ void AddMarkerAtPlayhead(otio::Item* item, std::string name, std::string color) 
     auto global_start = timeline->global_start_time().value_or(otio::RationalTime());
     auto time = timeline->tracks()->transformed_time(playhead - global_start, item, &error_status);
     if (otio::is_error(error_status)) {
-        Message(
+        ErrorMessage(
             "Error transforming time: %s",
             otio_error_string(error_status).c_str());
         return;
@@ -183,7 +183,7 @@ void AddTrack(std::string kind) {
             stack->insert_child(insertion_index, new_track, &error_status);
         }
         if (otio::is_error(error_status)) {
-            Message(
+            ErrorMessage(
                 "Error inserting track: %s",
                 otio_error_string(error_status).c_str());
             return;
@@ -194,24 +194,24 @@ void AddTrack(std::string kind) {
 void FlattenTrackDown() {
     const auto& timeline = appState.timeline;
     if (!timeline) {
-        Message("Cannot flatten: No timeline.");
+        ErrorMessage("Cannot flatten: No timeline.");
         return;
     }
 
     if (appState.selected_object == NULL) {
-        Message("Cannot flatten: No Track is selected.");
+        ErrorMessage("Cannot flatten: No Track is selected.");
         return;
     }
 
     auto selected_track = dynamic_cast<otio::Track*>(appState.selected_object);
     if (selected_track == NULL) {
-        Message("Cannot flatten: Selected object is not a Track.");
+        ErrorMessage("Cannot flatten: Selected object is not a Track.");
         return;
     }
 
     otio::Stack* stack = dynamic_cast<otio::Stack*>(selected_track->parent());
     if (stack == NULL) {
-        Message("Cannot flatten: Parent of selected Track is not a Stack.");
+        ErrorMessage("Cannot flatten: Parent of selected Track is not a Stack.");
         return;
     }
 
@@ -222,16 +222,16 @@ void FlattenTrackDown() {
         selected_index = (int)std::distance(children.begin(), it);
     }
     if (selected_index < 0) {
-        Message("Cannot flatten: Cannot find selected Track in Stack.");
+        ErrorMessage("Cannot flatten: Cannot find selected Track in Stack.");
         return;
     }
     if (selected_index == 0) {
-        Message("Cannot flatten: Selected Track has nothing below it.");
+        ErrorMessage("Cannot flatten: Selected Track has nothing below it.");
         return;
     }
     auto track_below = dynamic_cast<otio::Track*>(children[selected_index - 1].value);
     if (track_below == NULL) {
-        Message(
+        ErrorMessage(
             "Cannot flatten: Item below selected Track is not a Track itself.");
         return;
     }
@@ -242,7 +242,7 @@ void FlattenTrackDown() {
     tracks.push_back(selected_track);
     auto flat_track = otio::flatten_stack(tracks, &error_status);
     if (!flat_track || is_error(error_status)) {
-        Message("Cannot flatten: %s.", otio_error_string(error_status).c_str());
+        ErrorMessage("Cannot flatten: %s.", otio_error_string(error_status).c_str());
         return;
     }
     int insertion_index = selected_index + 1;
@@ -250,7 +250,7 @@ void FlattenTrackDown() {
     stack->insert_child(insertion_index, flat_track, &error_status);
 
     if (otio::is_error(error_status)) {
-        Message(
+        ErrorMessage(
             "Error inserting track: %s",
             otio_error_string(error_status).c_str());
         return;

--- a/editing.cpp
+++ b/editing.cpp
@@ -55,6 +55,48 @@ void DeleteSelectedObject() {
     }
 }
 
+void ReplaceObject(otio::SerializableObject* old_object, otio::SerializableObject* new_object) {
+    if (old_object == appState.timeline) {
+        appState.timeline = dynamic_cast<otio::Timeline*>(new_object);
+        return;
+    }
+
+    if (const auto& old_composable = dynamic_cast<otio::Composable*>(old_object)) {
+        if (const auto& parent = old_composable->parent()) {
+            auto& children = parent->children();
+            auto it = std::find(children.begin(), children.end(), old_composable);
+            if (it != children.end()) {
+                int index = (int)std::distance(children.begin(), it);
+                parent->remove_child(index);
+                parent->insert_child(index, dynamic_cast<otio::Composable*>(new_object));
+            }
+        }
+        return;
+    }
+
+    if (const auto& old_marker = dynamic_cast<otio::Marker*>(old_object)) {
+        if (const auto& item = dynamic_cast<otio::Item*>(appState.selected_context)) {
+            auto& markers = item->markers();
+            auto it = std::find(markers.begin(), markers.end(), old_marker);
+            if (it != markers.end()) {
+                *it = dynamic_cast<otio::Marker*>(new_object);
+            }
+        }
+        return;
+    }
+
+    if (const auto& old_effect = dynamic_cast<otio::Effect*>(old_object)) {
+        if (const auto& item = dynamic_cast<otio::Item*>(appState.selected_context)) {
+            auto& effects = item->effects();
+            auto it = std::find(effects.begin(), effects.end(), old_effect);
+            if (it != effects.end()) {
+                *it = dynamic_cast<otio::Effect*>(new_object);
+            }
+        }
+        return;
+    }
+}
+
 void AddMarkerAtPlayhead(otio::Item* item, std::string name, std::string color) {
     auto playhead = appState.playhead;
 

--- a/editing.h
+++ b/editing.h
@@ -4,7 +4,7 @@
 #include <opentimelineio/track.h>
 namespace otio = opentimelineio::OPENTIMELINEIO_VERSION;
 
-void ReplaceObject(otio::SerializableObject* old_object, otio::SerializableObject* new_object);
+bool ReplaceObject(otio::SerializableObject* old_object, otio::SerializableObject* new_object);
 void DeleteSelectedObject();
 void AddMarkerAtPlayhead(
     otio::Item* item = NULL,

--- a/editing.h
+++ b/editing.h
@@ -4,6 +4,7 @@
 #include <opentimelineio/track.h>
 namespace otio = opentimelineio::OPENTIMELINEIO_VERSION;
 
+void ReplaceObject(otio::SerializableObject* old_object, otio::SerializableObject* new_object);
 void DeleteSelectedObject();
 void AddMarkerAtPlayhead(
     otio::Item* item = NULL,

--- a/inspector.cpp
+++ b/inspector.cpp
@@ -137,10 +137,12 @@ void DrawJSONApplyEditButtons() {
         if (replacement_object == nullptr) {
             SetJSONErrorMessage("Error parsing JSON: Nil object result.");
         } else {
-            ReplaceObject(appState.selected_object, replacement_object);
-            SelectObject(replacement_object);
-            UpdateJSONInspector();
-            Message("Edits applied.");
+            auto success = ReplaceObject(appState.selected_object, replacement_object);
+            if (success) {
+                SelectObject(replacement_object);
+                UpdateJSONInspector();
+                Message("Edits applied.");
+            }
         }
     }
 

--- a/inspector.cpp
+++ b/inspector.cpp
@@ -73,14 +73,56 @@ TextEditor::LanguageDefinition otioLangDef = OTIOLanguageDef();
 bool json_rendered = false;
 bool json_edited = false;
 std::string json_error_message;
+int json_error_line = -1;
 
 void UpdateJSONInspector() {
     jsonEditor.SetReadOnly(false);
     jsonEditor.SetLanguageDefinition(otioLangDef);
     jsonEditor.SetText(appState.selected_text);
+    jsonEditor.SetErrorMarkers({});
     json_rendered = false;
     json_edited = false;
     json_error_message = "";
+    json_error_line = -1;
+}
+
+void SetJSONErrorMessage(std::string message) {
+    // Look for a pattern like "(line 123, column 45)" or
+    // "near line 54" in the error message and extract the line number.
+    std::regex line_number_regex("[ (]line ([0-9]+)");
+    std::smatch match;
+    if (std::regex_search(message, match, line_number_regex)) {
+        json_error_line = std::stoi(match[1]);
+    } else {
+        json_error_line = -1;
+    }
+
+    // Messages can be quite long, so let's line wrap
+    // the message at 80 characters, preserving words.
+    std::string wrapped_message;
+    int line_length = 0;
+    for (char c : message) {
+        if (c == '\n') {
+            line_length = 0;
+        } else {
+            line_length++;
+        }
+        if (line_length > 80 && c == ' ') {
+            wrapped_message += '\n';
+            line_length = 0;
+        }
+        wrapped_message += c;
+    }
+
+    if (json_error_line >= 0) {
+        jsonEditor.SetErrorMarkers({ { json_error_line, wrapped_message } });
+    } else {
+        jsonEditor.SetErrorMarkers({});
+    }
+
+    json_error_message = wrapped_message;
+
+    ErrorMessage("%s", json_error_message.c_str());
 }
 
 void DrawJSONApplyEditButtons() {
@@ -89,16 +131,16 @@ void DrawJSONApplyEditButtons() {
         auto replacement_json = jsonEditor.GetText();
         auto replacement_object = otio::SerializableObject::from_json_string(replacement_json, &error_status);
         if (is_error(error_status)) {
-            json_error_message = otio_error_string(error_status);
-            Message(json_error_message.c_str());
+            auto message = otio_error_string(error_status);
+            SetJSONErrorMessage(message);
         } else
         if (replacement_object == nullptr) {
-            json_error_message = "Error parsing JSON: Nil object result.";
-            Message(json_error_message.c_str());
+            SetJSONErrorMessage("Error parsing JSON: Nil object result.");
         } else {
             ReplaceObject(appState.selected_object, replacement_object);
             SelectObject(replacement_object);
             UpdateJSONInspector();
+            Message("Edits applied.");
         }
     }
 
@@ -106,12 +148,7 @@ void DrawJSONApplyEditButtons() {
 
     if (ImGui::Button("Revert")) {
         UpdateJSONInspector();
-    }
-
-    // If there's an error message, display it in red.
-    if (json_error_message != "") {
-        ImGui::SameLine();
-        ImGui::TextColored(ImVec4(1, 0, 0, 1), "%s", json_error_message.c_str());
+        Message("Edits reverted.");
     }
 }
 
@@ -242,7 +279,7 @@ bool DrawTimeRange(
 
     bool changed = false;
 
-    ImGui::Text("%s", label);
+    ImGui::TextUnformatted(label);
     ImGui::Indent();
 
     char buf[100];

--- a/inspector.cpp
+++ b/inspector.cpp
@@ -124,6 +124,11 @@ void DrawJSONInspector() {
         json_edited = true;
     }
 
+    auto available_size = ImGui::GetContentRegionAvail();
+    available_size.y -= ImGui::GetFrameHeightWithSpacing();
+    jsonEditor.Render("JSON",false, available_size);
+    json_rendered = true;
+
     if (json_edited) {
         DrawJSONApplyEditButtons();
     } else {
@@ -132,9 +137,6 @@ void DrawJSONInspector() {
         ImGui::EndDisabled();
     }
 
-    jsonEditor.Render("JSON");
-
-    json_rendered = true;
 }
 
 void DrawNonEditableTextField(const char* label, const char* format, ...) {

--- a/timeline.cpp
+++ b/timeline.cpp
@@ -1098,7 +1098,7 @@ bool DrawTransportControls(otio::Timeline* timeline) {
     ImGui::PushID("##TransportControls");
     ImGui::BeginGroup();
 
-    ImGui::Text("%s", start_string.c_str());
+    ImGui::TextUnformatted(start_string.c_str());
     ImGui::SameLine();
 
     ImGui::SetNextItemWidth(-270);
@@ -1114,7 +1114,7 @@ bool DrawTransportControls(otio::Timeline* timeline) {
     }
 
     ImGui::SameLine();
-    ImGui::Text("%s", end_string.c_str());
+    ImGui::TextUnformatted(end_string.c_str());
 
     ImGui::SameLine();
     ImGui::SetNextItemWidth(100);
@@ -1484,7 +1484,7 @@ void DrawTimeline(otio::Timeline* timeline) {
         // do this at the very end, so the playhead can overlay everything
         ImGui::TableNextRow(ImGuiTableRowFlags_None, 1);
         ImGui::TableNextColumn();
-        // ImGui::Text("%s", playhead_string.c_str());
+        // ImGui::TextUnformatted(playhead_string.c_str());
         ImGui::TableNextColumn();
         playhead_x = DrawPlayhead(
             start,

--- a/timeline.cpp
+++ b/timeline.cpp
@@ -731,7 +731,7 @@ void DrawTrack(
     otio::ErrorStatus error_status;
     auto range_map = track->range_of_all_children(&error_status);
     if (otio::is_error(error_status)) {
-        Message(
+        ErrorMessage(
             "Error calculating timing: %s",
             otio_error_string(error_status).c_str());
         assert(false);


### PR DESCRIPTION
This PR allows the raw text in the JSON tab in the inspector to be edited. Once any edit is made, the Apply and Revert buttons enable. Addresses #61 

After editing is complete, the user may press Apply to cause the text to be parsed, updating or replacing the selected object with the newly edited JSON, or Revert to discard the edits and return to the original.

If Apply is pressed, but a parse error occurs, a detailed error message is displayed in red. Clearing the text entirely produces an error. If you wish to delete an object, use the Delete menu item instead.

Copy and paste of text between objects or other applications work also. Note that the edit may completely replace the selected object, even with a different type of object, as long as the new object is valid in the context of the old one. For example, a Clip may replace a Gap, or a nested Stack, but a Marker cannot replace an Effect.

<img width="1392" alt="Screenshot 2025-02-14 at 11 29 10 PM" src="https://github.com/user-attachments/assets/4f46bc59-d0c2-45e2-ac70-fe093b0ac1cb" />
