### PR TITLE
Windows improve power usage

### DIFF
--- a/main_win32.cpp
+++ b/main_win32.cpp
@@ -40,7 +40,6 @@ void CALLBACK MessageFiberProc(LPVOID lpFiberParameter)
             if (msg.message == WM_QUIT)
                 g_done = true;
         }
-
         SwitchToFiber(g_mainFiber);
     }
 }
@@ -155,7 +154,7 @@ int main(int argc, char** argv)
 
         // NOTE: When compiled in Debug mode blocking doesn't always work for some reason.
 
-        if(cooldown_counter <= 0){
+        if (cooldown_counter <= 0){
             cooldown_counter = 5;
             WaitMessage();
         }else{


### PR DESCRIPTION
Brings Windows backend in line with Mac and glfw by adding a blocking wait to the main loop. Render at least 5 frames after a waiting for events.

I had a look at glfw's implementation of WaitEvents [here](https://github.com/glfw/glfw/blob/d299d9f78857e921b66bdab42c7ea27fe2e31810/src/win32_window.c#L2115) and applied the same idea here. I also added the cooldown timer that was added in #99. It seems to work fairly well with two caveats. Firstly, if you compile in debug mode the WaitMessage function doesn't seem to block, possibly because there are none user messages being sent and secondly it takes several seconds for the cool down to happen, if I load a large OTIO file the CPU usage spikes and then slowly drops off to zero over several seconds. Before this change CPU usage hovers at about 5% even when the app is minimised. 