### PR TITLE
Windows: Add missing ImPlot::CreateContext

### DIFF
--- a/main_win32.cpp
+++ b/main_win32.cpp
@@ -86,6 +86,7 @@ int main(int argc, char** argv)
     // Setup Dear ImGui context
     IMGUI_CHECKVERSION();
     ImGui::CreateContext();
+    ImPlot::CreateContext();
     ImGuiIO& io = ImGui::GetIO(); (void)io;
     io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard;       // Enable Keyboard Controls
     //io.ConfigFlags |= ImGuiConfigFlags_NavEnableGamepad;      // Enable Gamepad Controls


### PR DESCRIPTION
Raven on Windows was crashing when clips with a LinearTimeWarp effect were selected as the Windows backend was missing ImPlot::CreateContext()

Fixes #104