### PR TITLE
Append .otio file extension if missing at save

### DIFF
--- a/app.cpp
+++ b/app.cpp
@@ -377,7 +377,12 @@ otio::Timeline* LoadOTIOZFile(std::string path) {
 }
 
 std::string FileExtension(std::string path) {
-    return path.substr(path.find_last_of(".") + 1);
+    size_t period_position = path.find_last_of(".");
+    if (period_position != path.npos) {
+        return path.substr(period_position + 1);
+    } else {
+        return std::string("");
+    }
 }
 
 std::string LowerCase(std::string str) {
@@ -450,6 +455,20 @@ void SaveFile(std::string path) {
     auto timeline = appState.timeline;
     if (!timeline)
         return;
+
+    // Append .otio extension if missing
+    // Currently only supports saving as a .otio and not a .otioz
+    if (LowerCase(FileExtension(path)) == "")
+        path += ".otio";
+
+    // Incorrect file extension
+    if (LowerCase(FileExtension(path)) != "otio") {
+        ErrorMessage(
+            "Error saving \"%s\": Unsupported file type",
+            path.c_str());
+
+        return;
+    }
 
     auto start = std::chrono::high_resolution_clock::now();
 

--- a/app.cpp
+++ b/app.cpp
@@ -377,12 +377,7 @@ otio::Timeline* LoadOTIOZFile(std::string path) {
 }
 
 std::string FileExtension(std::string path) {
-    size_t period_position = path.find_last_of(".");
-    if (period_position != path.npos) {
-        return path.substr(period_position + 1);
-    } else {
-        return std::string("");
-    }
+    return std::filesystem::path(path).extension().generic_string();
 }
 
 std::string LowerCase(std::string str) {
@@ -424,9 +419,9 @@ void LoadFile(std::string path) {
     }
 
     auto ext = LowerCase(FileExtension(path));
-    if (ext == "otio") {
+    if (ext == ".otio") {
         timeline = LoadOTIOFile(path);
-    } else if (ext == "otioz") {
+    } else if (ext == ".otioz") {
         timeline = LoadOTIOZFile(path);
     } else {
         ErrorMessage(
@@ -462,7 +457,7 @@ void SaveFile(std::string path) {
         path += ".otio";
 
     // Incorrect file extension
-    if (LowerCase(FileExtension(path)) != "otio") {
+    if (LowerCase(FileExtension(path)) != ".otio") {
         ErrorMessage(
             "Error saving \"%s\": Unsupported file type",
             path.c_str());


### PR DESCRIPTION
Automatically append the `.otio` file extension to the file path if the user has omitted it.

Also extended the `FileExtension` function to return a blank string if there is no file extension present. Is there a better return value I could use here?

Fixes #94 