### PR TITLE
Load none Timeline schemas

### DIFF
--- a/app.cpp
+++ b/app.cpp
@@ -410,35 +410,27 @@ bool SupportedFileType(const std::string& filepath) {
 // These mostly set the root object to the right type and trigger the Inspector
 // to load but can also intiate custom UI loading (see LoadTimeline)
 bool LoadRoot(otio::SerializableObjectWithMetadata* root) {
-    if (root->schema_name() == "Timeline") {
-        auto timeline = dynamic_cast<otio::Timeline*>(root);
+    if (auto timeline = dynamic_cast<otio::Timeline*>(root)) {
         LoadTimeline(timeline);
-    } else if (root->schema_name() == "Clip") {
-        auto clip = dynamic_cast<otio::Clip*>(root);
+    } else if (auto clip = dynamic_cast<otio::Clip*>(root)) {
         appState.root = clip;
         SelectObject(clip);
-    } else if (root->schema_name() == "Gap") {
-        auto gap = dynamic_cast<otio::Gap*>(root);
+    } else if (auto gap = dynamic_cast<otio::Gap*>(root)) {
         appState.root = gap;
         SelectObject(gap);
-    } else if (root->schema_name() == "Transition") {
-        auto transition = dynamic_cast<otio::Transition*>(root);
+    } else if (auto transition = dynamic_cast<otio::Transition*>(root)) {
         appState.root = transition;
         SelectObject(transition);
-    } else if (root->schema_name() == "Effect") {
-        auto effect = dynamic_cast<otio::Effect*>(root);
+    } else if (auto effect = dynamic_cast<otio::Effect*>(root)) {
         appState.root = effect;
         SelectObject(effect);
-    } else if (root->schema_name() == "MediaReference") {
-        auto media_reference = dynamic_cast<otio::MediaReference*>(root);
+    } else if (auto media_reference = dynamic_cast<otio::MediaReference*>(root)) {
         appState.root = media_reference;
         SelectObject(media_reference);
-    } else if (root->schema_name() == "Marker") {
-        auto marker = dynamic_cast<otio::Marker*>(root);
+    } else if (auto marker = dynamic_cast<otio::Marker*>(root)) {
         appState.root = marker;
         SelectObject(marker);
-    } else if (root->schema_name() == "SerializableCollection") {
-        auto serializable_collection = dynamic_cast<otio::SerializableCollection*>(root);
+    } else if (auto serializable_collection = dynamic_cast<otio::SerializableCollection*>(root)) {
         appState.root = serializable_collection;
         SelectObject(serializable_collection);
     }

--- a/app.cpp
+++ b/app.cpp
@@ -300,16 +300,17 @@ otio::SerializableObjectWithMetadata* LoadOTIOFile(std::string path) {
     otio::ErrorStatus error_status;
     auto root = dynamic_cast<otio::SerializableObjectWithMetadata*>(
         otio::SerializableObjectWithMetadata::from_json_file(path, &error_status));
-    if (!root) {
-        ErrorMessage(
-            "Error loading \"%s\": Unable to extract OTIO data from input",
-            path.c_str());
-        return nullptr;
-    } else if (otio::is_error(error_status)) {
+
+    if (otio::is_error(error_status)) {
         ErrorMessage(
             "Error loading \"%s\": %s",
             path.c_str(),
             otio_error_string(error_status).c_str());
+        return nullptr;
+    } else if (!root) {
+        ErrorMessage(
+            "Error loading \"%s\": Unable to extract OTIO data from input",
+            path.c_str());
         return nullptr;
     }
     return root;
@@ -374,18 +375,18 @@ otio::SerializableObjectWithMetadata* LoadOTIOZFile(std::string path) {
                         otio::ErrorStatus error_status;
                         root = dynamic_cast<otio::SerializableObjectWithMetadata*>(
                             otio::SerializableObjectWithMetadata::from_json_string(json, &error_status));
-                        if (!root) {
-                            ErrorMessage(
-                                "Invalid OTIOZ: \"%s\": Unable to extract OTIO data from input",
-                                path.c_str());
-                        } else if (otio::is_error(error_status)) {
+                        if (otio::is_error(error_status)) {
                             ErrorMessage(
                                 "Invalid OTIOZ: \"%s\": %s",
                                 path.c_str(),
                                 otio_error_string(error_status).c_str());
-                                // Set root to nullptr rather than returning so we can still clean up
-                                // the zip reader
+                            // Set root to nullptr rather than returning so we can still clean up
+                            // the zip reader
                             root = nullptr;
+                        } else if (!root) {
+                            ErrorMessage(
+                                "Invalid OTIOZ: \"%s\": Unable to extract OTIO data from input",
+                                path.c_str());
                         }
                     }
                     free(buf);

--- a/app.cpp
+++ b/app.cpp
@@ -433,6 +433,12 @@ bool LoadRoot(otio::SerializableObjectWithMetadata* root) {
     } else if (auto serializable_collection = dynamic_cast<otio::SerializableCollection*>(root)) {
         appState.root = serializable_collection;
         SelectObject(serializable_collection);
+    } else if (auto track = dynamic_cast<otio::Track*>(root)) {
+        appState.root = track;
+        SelectObject(track);
+    } else if (auto stack = dynamic_cast<otio::Stack*>(root)) {
+        appState.root = stack;
+        SelectObject(stack);
     }
     else {
         return false;

--- a/app.h
+++ b/app.h
@@ -8,6 +8,7 @@
 #include "imgui_internal.h"
 
 #include <opentimelineio/timeline.h>
+#include <opentimelineio/serializableObjectWithMetadata.h>
 namespace otio = opentimelineio::OPENTIMELINEIO_VERSION;
 
 enum AppThemeCol_ {
@@ -83,7 +84,8 @@ struct AppState {
 
     // This holds the main timeline object.
     // Pretty much everything drills into this one entry point.
-    otio::SerializableObject::Retainer<otio::Timeline> timeline;
+    //otio::SerializableObject::Retainer<otio::Timeline> timeline;
+    otio::SerializableObject::Retainer<otio::SerializableObjectWithMetadata> root;
 
     // Timeline display settings
     float timeline_width = 100.0f; // automatically calculated (pixels)

--- a/inspector.cpp
+++ b/inspector.cpp
@@ -713,20 +713,27 @@ void DrawMarkersInspector() {
     typedef std::pair<otio::SerializableObject::Retainer<otio::Marker>, otio::SerializableObject::Retainer<otio::Item>> marker_parent_pair;
     std::vector<marker_parent_pair> pairs;
 
-    auto root = appState.timeline->tracks();
-    auto global_start = appState.timeline->global_start_time().value_or(otio::RationalTime());
+    auto root = new otio::Stack();
+    auto global_start = otio::RationalTime(0.0);
 
-    for (const auto& marker : root->markers()) {
-        pairs.push_back(marker_parent_pair(marker, root));
-    }
+    if (appState.root->schema_name() == "Timeline"){
+        const auto& timeline = dynamic_cast<otio::Timeline*>(appState.root.value);
 
-    for (const auto& child :
-         appState.timeline->tracks()->find_children())
-    {
-        if (const auto& item = dynamic_cast<otio::Item*>(&*child))
+        root = timeline->tracks();
+        global_start = timeline->global_start_time().value_or(otio::RationalTime());
+
+        for (const auto& marker : root->markers()) {
+            pairs.push_back(marker_parent_pair(marker, root));
+        }
+
+        for (const auto& child :
+            timeline->tracks()->find_children())
         {
-            for (const auto& marker : item->markers()) {
-                pairs.push_back(marker_parent_pair(marker, item));
+            if (const auto& item = dynamic_cast<otio::Item*>(&*child))
+            {
+                for (const auto& marker : item->markers()) {
+                    pairs.push_back(marker_parent_pair(marker, item));
+                }
             }
         }
     }
@@ -811,20 +818,27 @@ void DrawEffectsInspector() {
     typedef std::pair<otio::SerializableObject::Retainer<otio::Effect>, otio::SerializableObject::Retainer<otio::Item>> effect_parent_pair;
     std::vector<effect_parent_pair> pairs;
 
-    auto root = appState.timeline->tracks();
-    auto global_start = appState.timeline->global_start_time().value_or(otio::RationalTime());
+    auto root = new otio::Stack();
+    auto global_start = otio::RationalTime(0.0);
 
-    for (const auto& effect : root->effects()) {
-        pairs.push_back(effect_parent_pair(effect, root));
-    }
+    if (appState.root->schema_name() == "Timeline"){
+        const auto& timeline = dynamic_cast<otio::Timeline*>(appState.root.value);
 
-    for (const auto& child :
-         appState.timeline->tracks()->find_children())
-    {
-        if (const auto& item = dynamic_cast<otio::Item*>(&*child))
+        root = timeline->tracks();
+        global_start = timeline->global_start_time().value_or(otio::RationalTime());
+
+        for (const auto& effect : root->effects()) {
+            pairs.push_back(effect_parent_pair(effect, root));
+        }
+
+        for (const auto& child :
+            timeline->tracks()->find_children())
         {
-            for (const auto& effect : item->effects()) {
-                pairs.push_back(effect_parent_pair(effect, item));
+            if (const auto& item = dynamic_cast<otio::Item*>(&*child))
+            {
+                for (const auto& effect : item->effects()) {
+                    pairs.push_back(effect_parent_pair(effect, item));
+                }
             }
         }
     }

--- a/timeline.cpp
+++ b/timeline.cpp
@@ -46,7 +46,7 @@ void TopLevelTimeRangeMap(
     std::map<otio::Composable*, otio::TimeRange>& range_map,
     otio::Item* context) {
     auto zero = otio::RationalTime();
-    auto top = appState.timeline->tracks();
+    auto top = dynamic_cast<otio::Timeline*>(appState.root.value)->tracks();
     auto offset = context->transformed_time(zero, top);
 
     for (auto& pair : range_map) {


### PR DESCRIPTION
This is a replacement PR fro #86 as I royally messed up a merge and it was a lot easier and cleaner to start again from scratch.

Still a WIP but the root OTIO object is now a SerializableOjectWithMetadata to allow any OTIO schema to be loaded as the root object. Currently only supports Timeline and Clip schemas. Other schemas report an error and do nothing.  Currently when loading a clip as a root schema only the inspector renders so I guess there needs to be some discussion onhow best to render the main panel for other schemas.