### PR TITLE
Fix scrolling + subclasses

### DIFF
--- a/app.cpp
+++ b/app.cpp
@@ -757,9 +757,8 @@ void MainGui() {
 
         ImGui::EndChild();
 
-        if (appState.root && appState.root->schema_name() == "Timeline"){
-            appState.scroll_to_playhead = true;
-            if (DrawTransportControls(dynamic_cast<otio::Timeline*>(appState.root.value))) {
+        if (auto timeline = dynamic_cast<otio::Timeline*>(appState.root.value)) {
+            if (DrawTransportControls(timeline)) {
                 appState.scroll_to_playhead = true;
             }
         }

--- a/app.cpp
+++ b/app.cpp
@@ -605,8 +605,8 @@ void DrawRoot() {
     if (!appState.root){
         return;
     }
-    if (appState.root->schema_name() == "Timeline") {
-        DrawTimeline(dynamic_cast<otio::Timeline*>(appState.root.value));
+    if (auto timeline = dynamic_cast<otio::Timeline*>(appState.root.value)) {
+        DrawTimeline(timeline);
     }
 }
 
@@ -1150,8 +1150,7 @@ void SnapPlayhead() {
 }
 
 void DetectPlayheadLimits() {
-    if (appState.root->schema_name() == "Timeline"){
-        const auto timeline = dynamic_cast<otio::Timeline*>(appState.root.value);
+    if (auto timeline = dynamic_cast<otio::Timeline*>(appState.root.value)) {
         appState.playhead_limit = otio::TimeRange(
             timeline->global_start_time().value_or(otio::RationalTime()),
             timeline->duration());
@@ -1162,8 +1161,7 @@ void FitZoomWholeTimeline() {
     if (!appState.root){
         return;
     }
-    if (appState.root->schema_name() == "Timeline"){
-        const auto timeline = dynamic_cast<otio::Timeline*>(appState.root.value);
+    if (auto timeline = dynamic_cast<otio::Timeline*>(appState.root.value)) {
         appState.scale = appState.timeline_width / timeline->duration().to_seconds();
     }
 }

--- a/editing.cpp
+++ b/editing.cpp
@@ -142,11 +142,10 @@ void AddMarkerAtPlayhead(otio::Item* item, std::string name, std::string color) 
         return;
     }
 
-    if (appState.root->schema_name() != "Timeline"){
+    const auto& timeline = dynamic_cast<otio::Timeline*>(appState.root.value);
+    if (!timeline){
         return;
     }
-
-    const auto& timeline = dynamic_cast<otio::Timeline*>(appState.root.value);
 
     // Default to the selected item, or the top-level timeline.
     if (item == NULL) {
@@ -181,11 +180,10 @@ void AddTrack(std::string kind) {
         return;
     }
 
-    if (appState.root->schema_name() != "Timeline") {
+    const auto& timeline = dynamic_cast<otio::Timeline*>(appState.root.value);
+    if (!timeline) {
         return;
     }
-
-    const auto& timeline = dynamic_cast<otio::Timeline*>(appState.root.value);
 
     // Fall back to the top level stack.
     int insertion_index = -1;
@@ -246,11 +244,10 @@ void FlattenTrackDown() {
         return;
     }
 
-    if (appState.root->schema_name() != "Timeline") {
+    const auto& timeline = dynamic_cast<otio::Timeline*>(appState.root.value);
+    if (!timeline) {
         return;
     }
-
-    const auto& timeline = dynamic_cast<otio::Timeline*>(appState.root.value);
 
     if (!timeline) {
         ErrorMessage("Cannot flatten: No timeline.");

--- a/editing.cpp
+++ b/editing.cpp
@@ -240,15 +240,11 @@ void AddTrack(std::string kind) {
 }
 
 void FlattenTrackDown() {
-    if (!appState.root){
+    if (!appState.root) {
         return;
     }
 
     const auto& timeline = dynamic_cast<otio::Timeline*>(appState.root.value);
-    if (!timeline) {
-        return;
-    }
-
     if (!timeline) {
         ErrorMessage("Cannot flatten: No timeline.");
         return;

--- a/inspector.cpp
+++ b/inspector.cpp
@@ -717,9 +717,7 @@ void DrawMarkersInspector() {
     auto root = new otio::Stack();
     auto global_start = otio::RationalTime(0.0);
 
-    if (appState.root->schema_name() == "Timeline"){
-        const auto& timeline = dynamic_cast<otio::Timeline*>(appState.root.value);
-
+    if (const auto& timeline = dynamic_cast<otio::Timeline*>(appState.root.value)) {
         root = timeline->tracks();
         global_start = timeline->global_start_time().value_or(otio::RationalTime());
 
@@ -833,9 +831,7 @@ void DrawEffectsInspector() {
     auto root = new otio::Stack();
     auto global_start = otio::RationalTime(0.0);
 
-    if (appState.root->schema_name() == "Timeline"){
-        const auto& timeline = dynamic_cast<otio::Timeline*>(appState.root.value);
-
+    if (const auto& timeline = dynamic_cast<otio::Timeline*>(appState.root.value)) {
         root = timeline->tracks();
         global_start = timeline->global_start_time().value_or(otio::RationalTime());
 


### PR DESCRIPTION
This PR fixes two small issues.

First, as described in #117, the auto-scrolling was too aggressive. This was likely just a copy/paste or merge issue from a previous commit.

Second, the code now uses dynamic_cast instead of string comparisons on schema_name. This allows for the rare case where a file contains a subclass of a standard OTIO schema type which has a different name, but behaves the same via inheritance.

Each of these two fixes is split into a separate commit for review.
