### PR TITLE
Load file into tabs

### DIFF
--- a/app.cpp
+++ b/app.cpp
@@ -812,7 +812,7 @@ void MainGui() {
     ImGui::SetNextWindowDockID(dockspace_id, ImGuiCond_FirstUseEver);
     visible = ImGui::Begin("Tree", NULL, window_flags);
     if (visible) {
-        //DrawTreeInspector();
+        DrawTreeInspector();
     }
     ImGui::End();
 

--- a/app.cpp
+++ b/app.cpp
@@ -293,7 +293,7 @@ void LoadString(std::string json) {
 
     LoadTimeline(timeline);
 
-    appState.file_path = timeline->name().c_str();
+    appState.active_tab->file_path = timeline->name().c_str();
 
     auto end = std::chrono::high_resolution_clock::now();
     std::chrono::duration<double> elapsed = (end - start);
@@ -507,7 +507,7 @@ void LoadFile(std::string path) {
         return;
     }
 
-    appState.file_path = path;
+    appState.active_tab->file_path = path;
     appState.new_tab_opened = true;
 
     auto end = std::chrono::high_resolution_clock::now();
@@ -625,7 +625,7 @@ void MainGui() {
     AppUpdate();
 
     char window_title[1024];
-    auto filename = appState.file_path.substr(appState.file_path.find_last_of("/\\") + 1);
+    auto filename = appState.active_tab->file_path.substr(appState.active_tab->file_path.find_last_of("/\\") + 1);
     if (filename != "") {
         snprintf(
             window_title,
@@ -769,7 +769,13 @@ void MainGui() {
                     tab_bar_flags = ImGuiTabItemFlags_SetSelected;
                     appState.new_tab_opened = false;
                 }
-                if (tab->opened && ImGui::BeginTabItem((std::to_string(count)).c_str(), &tab->opened, tab_bar_flags)){
+                std::string tab_name;
+                if(tab->root.value->name().empty()){
+                    tab_name = tab->file_path.substr(tab->file_path.find_last_of("/\\") + 1);;
+                } else{
+                    tab_name = tab->root.value->name();
+                }
+                if (tab->opened && ImGui::BeginTabItem(tab_name.c_str(), &tab->opened, tab_bar_flags)){
                     appState.active_tab = tab;
 
                     // Wrap the timeline so we can control how much room is left below it
@@ -945,7 +951,7 @@ void DrawMenu() {
                     SaveFile(path);
             }
             if (ImGui::MenuItem("Revert")) {
-                LoadFile(appState.file_path);
+                LoadFile(appState.active_tab->file_path);
             }
             if (ImGui::MenuItem("Close", NULL, false, GetActiveRoot())) {
                 appState.tabs.clear();

--- a/app.cpp
+++ b/app.cpp
@@ -458,7 +458,6 @@ bool LoadRoot(otio::SerializableObjectWithMetadata* root) {
     } else if (auto serializable_collection = dynamic_cast<otio::SerializableCollection*>(GetActiveRoot())) {
         SelectObject(serializable_collection);
     } else {
-        appState.root = GetActiveRoot();
         SelectObject(root);
     }
 
@@ -949,7 +948,8 @@ void DrawMenu() {
                 LoadFile(appState.file_path);
             }
             if (ImGui::MenuItem("Close", NULL, false, GetActiveRoot())) {
-                appState.root = NULL;
+                appState.tabs.clear();
+                appState.active_tab = NULL;
                 SelectObject(NULL);
             }
 #ifndef EMSCRIPTEN

--- a/app.cpp
+++ b/app.cpp
@@ -508,7 +508,6 @@ void LoadFile(std::string path) {
     }
 
     appState.active_tab->file_path = path;
-    appState.new_tab_opened = true;
 
     auto end = std::chrono::high_resolution_clock::now();
     std::chrono::duration<double> elapsed = (end - start);
@@ -760,22 +759,18 @@ void MainGui() {
 
         ImGui::Separator();
 
-        if (ImGui::BeginTabBar("OpenTimelines")) {
+        ImGuiTabBarFlags tab_bar_flags = ImGuiTabBarFlags_AutoSelectNewTabs | ImGuiTabBarFlags_Reorderable;
+
+        if (ImGui::BeginTabBar("OpenTimelines", tab_bar_flags)) {
             int count = 0;
             for (auto tab : appState.tabs){
-                count++;
-                ImGuiTabBarFlags tab_bar_flags = ImGuiTabBarFlags_None;
-                if (tab == appState.tabs.back() && appState.new_tab_opened){
-                    tab_bar_flags = ImGuiTabItemFlags_SetSelected;
-                    appState.new_tab_opened = false;
-                }
                 std::string tab_name;
                 if(tab->root.value->name().empty()){
                     tab_name = tab->file_path.substr(tab->file_path.find_last_of("/\\") + 1);;
                 } else{
                     tab_name = tab->root.value->name();
                 }
-                if (tab->opened && ImGui::BeginTabItem(tab_name.c_str(), &tab->opened, tab_bar_flags)){
+                if (tab->opened && ImGui::BeginTabItem(tab_name.c_str(), &tab->opened)){
                     appState.active_tab = tab;
 
                     // Wrap the timeline so we can control how much room is left below it

--- a/app.cpp
+++ b/app.cpp
@@ -1193,7 +1193,7 @@ void FitZoomWholeTimeline() {
         return;
     }
     if (auto timeline = dynamic_cast<otio::Timeline*>(GetActiveRoot())) {
-        appState.scale = appState.timeline_width / timeline->duration().to_seconds();
+        appState.active_tab->scale = appState.timeline_width / timeline->duration().to_seconds();
     }
 }
 // GUI utility to add dynamic height to GUI elements

--- a/app.h
+++ b/app.h
@@ -77,6 +77,11 @@ struct AppTheme {
     ImU32 colors[AppThemeCol_COUNT];
 };
 
+struct TabData {
+    otio::SerializableObject::Retainer<otio::SerializableObjectWithMetadata> root;
+    bool opened = true;
+};
+
 // Struct that holds the application's state
 struct AppState {
     // What file did we load?
@@ -86,6 +91,10 @@ struct AppState {
     // Pretty much everything drills into this one entry point.
     //otio::SerializableObject::Retainer<otio::Timeline> timeline;
     otio::SerializableObject::Retainer<otio::SerializableObjectWithMetadata> root;
+
+    std::vector<TabData*> tabs;
+    TabData* active_tab;
+    bool new_tab_opened = false;
 
     // Timeline display settings
     float timeline_width = 100.0f; // automatically calculated (pixels)
@@ -135,6 +144,8 @@ void ErrorMessage(const char* format, ...);
 std::string Format(const char* format, ...);
 
 void LoadString(std::string json);
+
+otio::SerializableObjectWithMetadata* GetActiveRoot();
 
 std::string otio_error_string(otio::ErrorStatus const& error_status);
 

--- a/app.h
+++ b/app.h
@@ -78,21 +78,16 @@ struct AppTheme {
 };
 
 struct TabData {
+    // This holds the main timeline object.
+    // Pretty much everything drills into this one entry point.
     otio::SerializableObject::Retainer<otio::SerializableObjectWithMetadata> root;
     bool opened = true;
     float scale = 100.0f; // zoom scale, measured in pixels per second
+    std::string file_path; // What file did we load?
 };
 
 // Struct that holds the application's state
 struct AppState {
-    // What file did we load?
-    std::string file_path;
-
-    // This holds the main timeline object.
-    // Pretty much everything drills into this one entry point.
-    //otio::SerializableObject::Retainer<otio::Timeline> timeline;
-    //otio::SerializableObject::Retainer<otio::SerializableObjectWithMetadata> root;
-
     std::vector<TabData*> tabs;
     TabData* active_tab;
     bool new_tab_opened = false;

--- a/app.h
+++ b/app.h
@@ -90,7 +90,6 @@ struct TabData {
 struct AppState {
     std::vector<TabData*> tabs;
     TabData* active_tab;
-    bool new_tab_opened = false;
 
     // Timeline display settings
     float timeline_width = 100.0f; // automatically calculated (pixels)   

--- a/app.h
+++ b/app.h
@@ -90,7 +90,7 @@ struct AppState {
     // This holds the main timeline object.
     // Pretty much everything drills into this one entry point.
     //otio::SerializableObject::Retainer<otio::Timeline> timeline;
-    otio::SerializableObject::Retainer<otio::SerializableObjectWithMetadata> root;
+    //otio::SerializableObject::Retainer<otio::SerializableObjectWithMetadata> root;
 
     std::vector<TabData*> tabs;
     TabData* active_tab;

--- a/app.h
+++ b/app.h
@@ -80,6 +80,7 @@ struct AppTheme {
 struct TabData {
     otio::SerializableObject::Retainer<otio::SerializableObjectWithMetadata> root;
     bool opened = true;
+    float scale = 100.0f; // zoom scale, measured in pixels per second
 };
 
 // Struct that holds the application's state
@@ -97,8 +98,7 @@ struct AppState {
     bool new_tab_opened = false;
 
     // Timeline display settings
-    float timeline_width = 100.0f; // automatically calculated (pixels)
-    float scale = 100.0f; // zoom scale, measured in pixels per second
+    float timeline_width = 100.0f; // automatically calculated (pixels)   
     float default_track_height = 30.0f; // (pixels)
     float track_height = 30.0f; // current track height (pixels)
     otio::RationalTime playhead;

--- a/editing.cpp
+++ b/editing.cpp
@@ -8,8 +8,9 @@
 #include <stdlib.h>
 
 void DeleteSelectedObject() {
-    if (appState.selected_object == appState.root) {
-        appState.root = NULL;
+    if (appState.selected_object == GetActiveRoot()) {
+        appState.tabs.clear();
+        appState.active_tab = NULL;
         SelectObject(NULL);
         return;
     }
@@ -56,8 +57,8 @@ void DeleteSelectedObject() {
 }
 
 bool ReplaceObject(otio::SerializableObject* old_object, otio::SerializableObject* new_object) {
-    if (old_object == appState.root) {
-        appState.root = dynamic_cast<otio::SerializableObjectWithMetadata*>(new_object);
+    if (old_object == GetActiveRoot()) {
+        appState.active_tab->root = dynamic_cast<otio::SerializableObjectWithMetadata*>(new_object);
         return true;
     }
 
@@ -138,11 +139,11 @@ bool ReplaceObject(otio::SerializableObject* old_object, otio::SerializableObjec
 void AddMarkerAtPlayhead(otio::Item* item, std::string name, std::string color) {
     auto playhead = appState.playhead;
 
-    if (!appState.root){
+    if (!GetActiveRoot()){
         return;
     }
 
-    const auto& timeline = dynamic_cast<otio::Timeline*>(appState.root.value);
+    const auto& timeline = dynamic_cast<otio::Timeline*>(GetActiveRoot());
     if (!timeline){
         return;
     }
@@ -176,11 +177,11 @@ void AddMarkerAtPlayhead(otio::Item* item, std::string name, std::string color) 
 }
 
 void AddTrack(std::string kind) {
-    if (!appState.root){
+    if (!GetActiveRoot()){
         return;
     }
 
-    const auto& timeline = dynamic_cast<otio::Timeline*>(appState.root.value);
+    const auto& timeline = dynamic_cast<otio::Timeline*>(GetActiveRoot());
     if (!timeline) {
         return;
     }
@@ -240,11 +241,11 @@ void AddTrack(std::string kind) {
 }
 
 void FlattenTrackDown() {
-    if (!appState.root) {
+    if (!GetActiveRoot()) {
         return;
     }
 
-    const auto& timeline = dynamic_cast<otio::Timeline*>(appState.root.value);
+    const auto& timeline = dynamic_cast<otio::Timeline*>(GetActiveRoot());
     if (!timeline) {
         ErrorMessage("Cannot flatten: No timeline.");
         return;

--- a/inspector.cpp
+++ b/inspector.cpp
@@ -1029,6 +1029,7 @@ void DrawTreeInspector() {
             }
             ImGui::TreePop();
         }
+        ImGui::PopID();
     };
 
     if (ImGui::BeginTable("Tree",

--- a/inspector.cpp
+++ b/inspector.cpp
@@ -717,7 +717,7 @@ void DrawMarkersInspector() {
     auto root = new otio::Stack();
     auto global_start = otio::RationalTime(0.0);
 
-    if (const auto& timeline = dynamic_cast<otio::Timeline*>(appState.root.value)) {
+    if (const auto& timeline = dynamic_cast<otio::Timeline*>(GetActiveRoot())) {
         root = timeline->tracks();
         global_start = timeline->global_start_time().value_or(otio::RationalTime());
 
@@ -831,7 +831,7 @@ void DrawEffectsInspector() {
     auto root = new otio::Stack();
     auto global_start = otio::RationalTime(0.0);
 
-    if (const auto& timeline = dynamic_cast<otio::Timeline*>(appState.root.value)) {
+    if (const auto& timeline = dynamic_cast<otio::Timeline*>(GetActiveRoot())) {
         root = timeline->tracks();
         global_start = timeline->global_start_time().value_or(otio::RationalTime());
 
@@ -936,10 +936,10 @@ void DrawTreeInspector() {
     otio::Composition* tree_root = nullptr;
     otio::RationalTime global_start = otio::RationalTime();
 
-    if (auto timeline = dynamic_cast<otio::Timeline*>(appState.root.value)) {
+    if (auto timeline = dynamic_cast<otio::Timeline*>(GetActiveRoot())) {
         tree_root = timeline->tracks();
         auto global_start = timeline->global_start_time().value_or(otio::RationalTime());
-    }else if (auto composition = dynamic_cast<otio::Composition*>(appState.root.value)) {
+    }else if (auto composition = dynamic_cast<otio::Composition*>(GetActiveRoot())) {
         tree_root = composition;
     }else{
         ImGui::Text("Root is not a Timeline or Composition");

--- a/timeline.cpp
+++ b/timeline.cpp
@@ -48,7 +48,7 @@ void TopLevelTimeRangeMap(
     std::map<otio::Composable*, otio::TimeRange>& range_map,
     otio::Item* context) {
     auto zero = otio::RationalTime();
-    auto top = dynamic_cast<otio::Timeline*>(appState.root.value)->tracks();
+    auto top = dynamic_cast<otio::Timeline*>(GetActiveRoot())->tracks();
     auto offset = context->transformed_time(zero, top);
 
     for (auto& pair : range_map) {
@@ -1511,7 +1511,7 @@ void DrawTimeline(otio::Timeline* timeline) {
             // we want the 2nd column to always fit the timeline content.
             // Add some padding, so you can read the playhead label when it sticks off
             // the end.
-            ImGui::TableSetColumnWidth(1, fmaxf(0.0f, full_width) + 200.0f);
+            //ImGui::TableSetColumnWidth(1, fmaxf(0.0f, full_width) + 200.0f);
         }
         // Always show the track labels & the playhead track
         ImGui::TableSetupScrollFreeze(1, 1);

--- a/timeline.cpp
+++ b/timeline.cpp
@@ -1153,13 +1153,13 @@ bool DrawTransportControls(otio::Timeline* timeline) {
     ImGui::SetNextItemWidth(100);
     if (ImGui::SliderFloat(
             "##Zoom",
-            &appState.scale,
+            &appState.active_tab->scale,
             0.1f,
             5000.0f,
             "Zoom",
             ImGuiSliderFlags_Logarithmic)) {
         // never go to 0 or less
-        appState.scale = fmax(0.0001f, appState.scale);
+        appState.active_tab->scale = fmax(0.0001f, appState.active_tab->scale);
         moved_playhead = true;
     }
 
@@ -1487,7 +1487,7 @@ void DrawTimeline(otio::Timeline* timeline) {
     auto available_size = ImGui::GetContentRegionAvail();
     appState.timeline_width = 0.8f * available_size.x;
 
-    float full_width = duration.to_seconds() * appState.scale;
+    float full_width = duration.to_seconds() * appState.active_tab->scale;
     float full_height = available_size.y - ImGui::GetFrameHeightWithSpacing();
 
     static ImVec2 cell_padding(2.0f, 0.0f);
@@ -1531,7 +1531,7 @@ void DrawTimeline(otio::Timeline* timeline) {
                 start,
                 end,
                 playhead.rate(),
-                appState.scale,
+                appState.active_tab->scale,
                 full_width,
                 appState.track_height)) {
             // scroll_to_playhead = true;
@@ -1540,7 +1540,7 @@ void DrawTimeline(otio::Timeline* timeline) {
         std::map<otio::Composable*, otio::TimeRange> empty_map;
         DrawMarkers(
             timeline->tracks(),
-            appState.scale,
+            appState.active_tab->scale,
             origin,
             appState.track_height,
             empty_map);
@@ -1550,7 +1550,7 @@ void DrawTimeline(otio::Timeline* timeline) {
             start,
             end,
             playhead,
-            appState.scale,
+            appState.active_tab->scale,
             full_width,
             appState.track_height,
             appState.track_height,
@@ -1573,7 +1573,7 @@ void DrawTimeline(otio::Timeline* timeline) {
                 DrawTrack(
                     video_track,
                     index,
-                    appState.scale,
+                    appState.active_tab->scale,
                     origin,
                     full_width,
                     appState.track_height);
@@ -1601,7 +1601,7 @@ void DrawTimeline(otio::Timeline* timeline) {
                 DrawTrack(
                     audio_track,
                     index,
-                    appState.scale,
+                    appState.active_tab->scale,
                     origin,
                     full_width,
                     appState.track_height);
@@ -1622,7 +1622,7 @@ void DrawTimeline(otio::Timeline* timeline) {
                 DrawTrack(
                     other_track,
                     index,
-                    appState.scale,
+                    appState.active_tab->scale,
                     origin,
                     full_width,
                     appState.track_height);
@@ -1647,7 +1647,7 @@ void DrawTimeline(otio::Timeline* timeline) {
             start,
             end,
             playhead,
-            appState.scale,
+            appState.active_tab->scale,
             full_width,
             appState.track_height,
             full_height,


### PR DESCRIPTION
I made a start at implementing #64 and have promising results. Files now open into new tabs and the inspector displays whichever item you select.

The main changes were creating a new struct that goes inside `AppState` and stores all the data required for a given tab, namely the root object of that tab, the timeline scale ad the file path associated with that tab.
```
struct TabData {
    // This holds the main timeline object.
    // Pretty much everything drills into this one entry point.
    otio::SerializableObject::Retainer<otio::SerializableObjectWithMetadata> root;
    bool opened = true;
    float scale = 100.0f; // zoom scale, measured in pixels per second
    std::string file_path; // What file did we load?
};
```

Most of the rest of the changes are updating everything to work with the new data structure. There is now a `GetActiveRoot()` function that returns the root object of the active tab and should be used wherever you would have used `appState.root`. Actually implementing the tabs in the UI is fairly simple, I wrapped the existing Timeline draw code in a `BeginTabBar` section. 

The main things left to do are handle closing tabs and opening the same file multiple times. More testing would also be good as  there are undoubtably some bugs in there.