### PR TITLE
Fix #116: Fixes the Emscripten builds

### DIFF
--- a/app.cpp
+++ b/app.cpp
@@ -285,8 +285,6 @@ void LoadString(std::string json) {
 
     LoadRoot(root);
 
-    appState.file_path = root->name().c_str();
-
     auto end = std::chrono::high_resolution_clock::now();
     std::chrono::duration<double> elapsed = (end - start);
     double elapsed_seconds = elapsed.count();

--- a/app.cpp
+++ b/app.cpp
@@ -274,25 +274,25 @@ void LoadString(std::string json) {
     auto start = std::chrono::high_resolution_clock::now();
 
     otio::ErrorStatus error_status;
-    auto timeline = dynamic_cast<otio::Timeline*>(
-        otio::Timeline::from_json_string(json, &error_status));
-    if (!timeline || otio::is_error(error_status)) {
+    auto root = dynamic_cast<otio::SerializableObjectWithMetadata*>(
+        otio::SerializableObjectWithMetadata::from_json_string(json, &error_status));
+    if (!root || otio::is_error(error_status)) {
         ErrorMessage(
             "Error loading JSON: %s",
             otio_error_string(error_status).c_str());
         return;
     }
 
-    LoadTimeline(timeline);
+    LoadRoot(root);
 
-    appState.file_path = timeline->name().c_str();
+    appState.file_path = root->name().c_str();
 
     auto end = std::chrono::high_resolution_clock::now();
     std::chrono::duration<double> elapsed = (end - start);
     double elapsed_seconds = elapsed.count();
     Message(
         "Loaded \"%s\" in %.3f seconds",
-        timeline->name().c_str(),
+        root->name().c_str(),
         elapsed_seconds);
 }
 

--- a/app.h
+++ b/app.h
@@ -135,6 +135,7 @@ void ErrorMessage(const char* format, ...);
 std::string Format(const char* format, ...);
 
 void LoadString(std::string json);
+bool LoadRoot(otio::SerializableObjectWithMetadata* root);
 
 std::string otio_error_string(otio::ErrorStatus const& error_status);
 


### PR DESCRIPTION
Fixes the Emscripten builds by updating LoadString to use the root object (SerializableObjectWithMetadata).

Given `LoadString()` is only used by then Emscripten builds should it be moved to `main_emscripten.cpp`?

Fixes https://github.com/OpenTimelineIO/raven/issues/116