### PR TITLE
Build: adding support for distribution via Python package

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,23 @@ You can load a file into WASM Raven a few ways:
 
 Note: The WASM build of raven is missing some features - see the Help Wanted section below.
 
+## Building (as a Python package)
+
+Raven can be built and embedded inside a Python package for easy distribution alongside other OTIO Python packages.
+For simplicity, we recommend using [UV](https://github.com/astral-sh/uv) for builds and running Raven from the Python package.
+
+```shell
+# clone the code
+git clone --recursive https://github.com/OpenTimelineIO/raven.git
+cd raven
+
+# run Raven using UV
+uv run --no-editable raven example.otio
+
+# build wheel using UV (wheel file will be in ./dist)
+uv build # add '--python <python_version>' to build for a specific Python version
+```
+
 ## Troubleshooting
 
 If you have trouble building, these hints might help...

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,21 @@
+[build-system]
+requires = ["scikit-build-core"]
+build-backend = "scikit_build_core.build"
+
+[project]
+name = "opentimelineio-raven"
+version = "0.1.0"
+description = "OTIO Viewer - C++ executable bundled as a Python package"
+authors = [{ name = "Your Name", email = "your@email.com" }]
+license = { file = "LICENSE.txt" }
+readme = "README.md"
+requires-python = ">=3.7"
+
+[project.scripts]
+raven = "otio_raven._wrapper:main"
+
+[tool.scikit-build]
+cmake.version = ">=3.10"
+cmake.build-type = "Release"
+wheel.packages = ["python/otio_raven"]
+wheel.install-dir = "otio_raven"

--- a/python/otio_raven/_wrapper.py
+++ b/python/otio_raven/_wrapper.py
@@ -1,0 +1,8 @@
+import sys
+import subprocess
+import os
+
+def main():
+    package_dir = os.path.dirname(__file__)
+    exe_path = os.path.join(package_dir, "bin", "raven")
+    sys.exit(subprocess.call([exe_path] + sys.argv[1:]))


### PR DESCRIPTION
## Feature

This adds support for building and distributing Raven as a Python package. While this might seem a bit odd given that Raven currently doesn't have any Python dependencies, it has some distinct advantages:

- easily installed using pip just like the other OTIO repos
- tools like UV will enable running Raven with a single command (no cloning needed) once we publish it to PyPI

```shell
# clone the code
git clone --recursive https://github.com/OpenTimelineIO/raven.git
cd raven

# run Raven using UV from local code
uv run --no-editable raven example.otio

# build wheel using UV (wheel file will be in ./dist)
uv build # add '--python <python_version>' to build for a specific Python version

# run Raven directly off PyPi
uvx opentimelineio-raven raven example.otio
```