### PR TITLE
Allow opening multiple files when launching

### DIFF
--- a/app.cpp
+++ b/app.cpp
@@ -586,7 +586,41 @@ void MainInit(int argc, char** argv, int initial_width, int initial_height) {
     LoadFonts();
 
     if (argc > 1) {
-        LoadFile(argv[1]);
+        std::string first_file = argv[1];
+
+        // If the first argument contains a wild card try and open all files in that folder,
+        // if not open all the files given as arguments
+        if (std::filesystem::path(first_file).filename().string().find("*") != std::string::npos) {
+            auto extension = LowerCase(FileExtension(first_file));
+
+            // Check valid extension
+            if (!SupportedFileType(first_file)) {
+                ErrorMessage(
+                    "Unsuported file type \"%s\"",
+                    first_file.c_str());
+                return;
+            }
+
+            // Get base path
+            int index_of_wildcard = first_file.find_last_of("*");
+            std::string base_path = first_file.substr(0, index_of_wildcard);
+            if (base_path.empty()) {
+                base_path = ".";
+            }
+
+            std::cout << "Loading all " << extension << " files in " << base_path << std::endl;
+
+            // Iterate through directory and load all files with the given extension
+            for (auto const& dir_entry : std::filesystem::directory_iterator(base_path))
+                if (dir_entry.path().extension().string() == extension) {
+                    LoadFile(dir_entry.path().string());
+                }
+        } else {
+            // Load each specified file
+            for (int i = 1; i < argc; i++) {
+                LoadFile(argv[i]);
+            }
+        }
     }
 }
 


### PR DESCRIPTION
After completing #123 it was suggested it would be good to implement loading multiple files at launch. I've attempted that in the following way:

On launch check if the first file presented contains a wild card and if so attempt to open all files in the given directory that have the same file extension. If the first file does not contain a wild card, try top open all files presented.

This seems to work pretty well but could do with a bit of testing, especially on none Windows platforms as there is always path weirdness to contend with.

Examples:
```
// Open a.otio, b.otio, c.otio
raven.exe a.otio b.otio c.otioz

// Open all otio files in current folder
raven *.otio

// Open all otioz files in specified folder
raven path/to/my/folder/*.otioz
```