### PR TITLE
Use native otioz support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,12 @@ include_directories(
   ${PROJECT_SOURCE_DIR}/libs/nativefiledialog/src/include
 )
 
+# OTIO links minizip-ng for .otioz support. Use raven's copy (built below)
+# instead of OTIO's vendored one, which does not build under Emscripten,
+# and skip OTIO's submodule update at configure time.
+list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
+set(OTIO_FIND_MINIZIP_NG ON)
+set(OTIO_AUTOMATIC_SUBMODULES OFF)
 set(OTIO_SHARED_LIBS OFF)
 add_subdirectory("libs/opentimelineio")
 include_directories(
@@ -105,7 +111,6 @@ target_compile_definitions(raven
 target_link_libraries(raven PUBLIC
     OTIO::opentimelineio
     IMGUI
-    MINIZIP::minizip
 )
 
 if (APPLE)

--- a/app.cpp
+++ b/app.cpp
@@ -17,11 +17,7 @@
 #include "nfd.h"
 #endif
 
-#include "mz.h"
-#include "mz_zip.h"
-#include "mz_strm.h"
-#include "mz_zip_rw.h"
-
+#include <opentimelineio/bundle.h>
 #include <opentimelineio/clip.h>
 #include <opentimelineio/gap.h>
 #include <opentimelineio/transition.h>
@@ -325,90 +321,7 @@ otio::SerializableObjectWithMetadata* LoadOTIOFile(std::string path) {
 }
 
 otio::SerializableObjectWithMetadata* LoadOTIOZFile(std::string path) {
-    otio::SerializableObjectWithMetadata* root = nullptr;
-
-    void *zip_reader = mz_zip_reader_create();
-
-    auto status = mz_zip_reader_open_file(zip_reader, path.c_str());
-    if (status != MZ_OK) {
-        ErrorMessage(
-            "Error opening \"%s\": %d",
-            path.c_str(),
-            status);
-    } else {
-        status = mz_zip_reader_locate_entry(zip_reader, "content.otio", 1);
-        if (status != MZ_OK) {
-            ErrorMessage(
-                "Invalid OTIOZ: \"%s\": \"content.otio\" not found in archive.",
-                path.c_str());
-        } else {
-            mz_zip_file *file_info = NULL;
-            status = mz_zip_reader_entry_get_info(zip_reader, &file_info);
-            if (status != MZ_OK) {
-                ErrorMessage(
-                    "Invalid OTIOZ: \"%s\": Error getting entry info: %d",
-                    path.c_str(),
-                    status);
-            } else {
-                status = mz_zip_reader_entry_open(zip_reader);
-                if (status != MZ_OK) {
-                    ErrorMessage(
-                        "Invalid OTIOZ: \"%s\": Unable to open entry: %d",
-                        path.c_str(),
-                        status);
-                } else {
-                    char* buf = (char*)malloc(file_info->uncompressed_size + 1);
-                    char* buf_cursor = buf;
-                    int64_t bytes_remaining = file_info->uncompressed_size;
-                    int32_t bytes_read = 0;
-                    while (bytes_remaining > 0) {
-                        int32_t chunk_size = bytes_remaining < INT32_MAX ? bytes_remaining : INT32_MAX;
-                        bytes_read = mz_zip_reader_entry_read(zip_reader, buf_cursor, chunk_size);
-                        if (bytes_read > 0) {
-                            bytes_remaining -= bytes_read;
-                            buf_cursor += bytes_read;
-                        } else {
-                            break;
-                        }
-                    }
-                    if (bytes_remaining != 0) {
-                        ErrorMessage(
-                            "Invalid OTIOZ: \"%s\": Error reading entry: %ld",
-                            path.c_str(),
-                            bytes_remaining);
-                    } else {
-                        // Add a null terminator
-                        buf[file_info->uncompressed_size] = '\0';
-                        std::string json(buf);
-                        otio::ErrorStatus error_status;
-                        root = dynamic_cast<otio::SerializableObjectWithMetadata*>(
-                            otio::SerializableObjectWithMetadata::from_json_string(json, &error_status));
-                        if (otio::is_error(error_status)) {
-                            ErrorMessage(
-                                "Invalid OTIOZ: \"%s\": %s",
-                                path.c_str(),
-                                otio_error_string(error_status).c_str());
-                            // Set root to nullptr rather than returning so we can still clean up
-                            // the zip reader
-                            root = nullptr;
-                        } else if (!root) {
-                            ErrorMessage(
-                                "Invalid OTIOZ: \"%s\": Unable to extract OTIO data from input",
-                                path.c_str());
-                        }
-                    }
-                    free(buf);
-                    mz_zip_reader_entry_close(zip_reader);
-                }
-            }
-        }
-
-        mz_zip_reader_close(zip_reader);
-    }
-
-    mz_zip_reader_delete(&zip_reader);
-
-    return root;
+    return dynamic_cast<otio::SerializableObjectWithMetadata*>(otio::bundle::read_otioz(path));
 }
 
 std::string FileExtension(std::string path) {

--- a/app.h
+++ b/app.h
@@ -9,7 +9,7 @@
 
 #include <opentimelineio/timeline.h>
 #include <opentimelineio/serializableObjectWithMetadata.h>
-namespace otio = opentimelineio::OPENTIMELINEIO_VERSION;
+namespace otio = opentimelineio::OPENTIMELINEIO_VERSION_NS;
 
 enum AppThemeCol_ {
     AppThemeCol_Background,

--- a/cmake/Findminizip-ng.cmake
+++ b/cmake/Findminizip-ng.cmake
@@ -1,0 +1,4 @@
+# raven builds minizip-ng itself with add_subdirectory(), so OTIO's
+# find_package(minizip-ng) only needs to report success here; the
+# MINIZIP::minizip target is resolved when the build files are generated.
+set(minizip-ng_FOUND TRUE)

--- a/colors.cpp
+++ b/colors.cpp
@@ -3,7 +3,7 @@
 #include "imgui_internal.h"
 
 #include <opentimelineio/marker.h>
-namespace otio = opentimelineio::OPENTIMELINEIO_VERSION;
+namespace otio = opentimelineio::OPENTIMELINEIO_VERSION_NS;
 
 ImU32 LerpColors(ImU32 col_a, ImU32 col_b, float t) {
     int r = ImLerp(
@@ -26,7 +26,8 @@ ImU32 LerpColors(ImU32 col_a, ImU32 col_b, float t) {
 }
 
 ImU32 UIColorFromName(std::string color) {
-    if (color == otio::Marker::Color::pink)
+    // \todo
+    /*if (color == otio::Marker::Color::pink)
         return IM_COL32(0xff, 0x70, 0x70, 0xff);
     if (color == otio::Marker::Color::red)
         return IM_COL32(0xff, 0x00, 0x00, 0xff);
@@ -47,7 +48,7 @@ ImU32 UIColorFromName(std::string color) {
     if (color == otio::Marker::Color::black)
         return IM_COL32(0x00, 0x00, 0x00, 0xff);
     if (color == otio::Marker::Color::white)
-        return IM_COL32(0xff, 0xff, 0xff, 0xff);
+        return IM_COL32(0xff, 0xff, 0xff, 0xff);*/
     return IM_COL32(0x88, 0x88, 0x88, 0xff);
 }
 

--- a/editing.cpp
+++ b/editing.cpp
@@ -176,7 +176,8 @@ void AddMarkerAtPlayhead(otio::Item* item, std::string name, std::string color) 
     }
 
     const auto marked_range = otio::TimeRange(time); // default 0 duration
-    otio::SerializableObject::Retainer<otio::Marker> marker = new otio::Marker(name, marked_range, color);
+    // \todo
+    otio::SerializableObject::Retainer<otio::Marker> marker = new otio::Marker(name, marked_range);
 
     item->markers().push_back(marker);
 }

--- a/editing.h
+++ b/editing.h
@@ -2,7 +2,7 @@
 
 #include <opentimelineio/item.h>
 #include <opentimelineio/track.h>
-namespace otio = opentimelineio::OPENTIMELINEIO_VERSION;
+namespace otio = opentimelineio::OPENTIMELINEIO_VERSION_NS;
 
 bool ReplaceObject(otio::SerializableObject* old_object, otio::SerializableObject* new_object);
 void DeleteSelectedObject();

--- a/inspector.cpp
+++ b/inspector.cpp
@@ -737,7 +737,8 @@ void DrawInspector() {
     }
 
     // Marker
-    if (const auto& marker = dynamic_cast<otio::Marker*>(selected_object)) {
+    // \todo
+    /*if (const auto& marker = dynamic_cast<otio::Marker*>(selected_object)) {
         auto rate = marker->marked_range().start_time().rate();
 
         auto color_name = DrawColorChooser(marker->color());
@@ -754,7 +755,7 @@ void DrawInspector() {
         if (DrawTimeRange("Marked Range", &marked_range, false)) {
             marker->set_marked_range(marked_range);
         }
-    }
+    }*/
 
     // Track
     if (const auto& track = dynamic_cast<otio::Track*>(selected_object)) {
@@ -986,7 +987,7 @@ void DrawMarkersInspector() {
                 // Color + Name
                 ImGui::TableNextColumn();
 
-                ImGui::PushStyleColor(ImGuiCol_Text, UIColorFromName(marker->color()));
+                ImGui::PushStyleColor(ImGuiCol_Text, UIColorFromName(marker->color()->name()));
                 ImGui::TextUnformatted("\xef\x80\xab");
                 ImGui::PopStyleColor();
                 ImGui::SameLine();

--- a/timeline.cpp
+++ b/timeline.cpp
@@ -549,7 +549,7 @@ void DrawMarkers(
                 + origin.x - arrow_width / 2,
             ImGui::GetCursorPosY());
 
-        auto fill_color = UIColorFromName(marker->color());
+        auto fill_color = UIColorFromName(marker->color()->name());
         auto selected_fill_color = appTheme.colors[AppThemeCol_MarkerSelected];
         auto hover_fill_color = appTheme.colors[AppThemeCol_MarkerHovered];
 
@@ -607,7 +607,7 @@ void DrawMarkers(
                 "%s: %s\nColor: %s\nRange: %s - %s\nDuration: %s",
                 marker->schema_name().c_str(),
                 marker->name().c_str(),
-                marker->color().c_str(),
+                marker->color()->name().c_str(),
                 FormattedStringFromTime(range.start_time()).c_str(),
                 FormattedStringFromTime(range.end_time_exclusive()).c_str(),
                 FormattedStringFromTime(duration).c_str());

--- a/timeline.h
+++ b/timeline.h
@@ -1,7 +1,7 @@
 // Timeline widget
 
 #include <opentimelineio/timeline.h>
-namespace otio = opentimelineio::OPENTIMELINEIO_VERSION;
+namespace otio = opentimelineio::OPENTIMELINEIO_VERSION_NS;
 
 void DrawTimeline(otio::Timeline* timeline);
 bool DrawTransportControls(otio::Timeline* timeline);


### PR DESCRIPTION
This PR adds support for native C++ .otioz functionality.

The new .otioz functionality has not been released yet, so this is a draft to demonstrate the changes. Also it looks like the latest OTIO code has some API changes around marker colors which this does not address (I temporarily commented out the relevant code).

I also needed to update the macOS runner to `macos-14` since `macos-13` has been retired.

Example .otioz file:

<img width="1392" height="908" alt="Screenshot 2026-07-14 at 9 23 13 AM" src="https://github.com/user-attachments/assets/8aeb3f2f-8798-4d10-befb-04ecf9f089da" />

Assisted-by: Claude:claude-opus-4-7 [code-review] [debugging]