### PR TITLE
Various CI fixes

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -94,12 +94,20 @@ jobs:
         emsdk-master/emsdk install latest
         emsdk-master/emsdk activate latest
 
+    - name: Pre-build zlib port
+      run: |
+        source emsdk-master/emsdk_env.sh
+        embuilder build zlib
+
     - name: Build
       run: |
         source emsdk-master/emsdk_env.sh
         mkdir build-web
         cd build-web
-        emcmake cmake ..
+        emcmake cmake .. \
+            -DCMAKE_C_FLAGS="-sUSE_ZLIB=1" \
+            -DCMAKE_CXX_FLAGS="-sUSE_ZLIB=1" \
+            -DCMAKE_EXE_LINKER_FLAGS="-sUSE_ZLIB=1"
         cmake --build . --parallel 4
 
     - name: Check Product
@@ -117,12 +125,17 @@ jobs:
         name: raven-web.zip
         path: build-web/raven-web.zip
   Windows:
-    runs-on: windows-latest
+    runs-on: windows-2022
     steps:
     - uses: actions/checkout@v5
       with:
         fetch-depth: 1
         submodules: recursive
+
+    - name: Install ZLIB
+      run: |
+        vcpkg install zlib:x64-windows
+        echo "CMAKE_PREFIX_PATH=C:/vcpkg/installed/x64-windows" >> $env:GITHUB_ENV
 
     - name: Build
       run: |
@@ -131,6 +144,15 @@ jobs:
         cmake ..
         cmake --build . --config Debug --parallel 4
         cmake --build . --config Release --parallel 4
+
+    # vcpkg's zlib port renames the Windows DLL to z.dll (not zlib1.dll).
+    # raven.exe links against it, so bundle it into the archive next to
+    # raven.exe so users who download the artifact can actually run it.
+    - name: Bundle ZLIB DLL for archive
+      shell: pwsh
+      run: |
+        Copy-Item "C:/vcpkg/installed/x64-windows/bin/*.dll" "build_win64/Debug/"
+        Copy-Item "C:/vcpkg/installed/x64-windows/bin/*.dll" "build_win64/Release/"
 
     - name: Check Product
       shell: bash
@@ -155,17 +177,22 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.9"]
-        os: [ ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-13, macos-latest ]
+        os: [ ubuntu-latest, ubuntu-24.04-arm, windows-2022, macos-14, macos-latest ]
     steps:
     - uses: actions/checkout@v5
       with:
         fetch-depth: 1
         submodules: recursive
-    - name: Install Dependencies
+    - name: Install Dependencies (Linux)
       run: |
         sudo apt-get update
         sudo apt-get install -y libglfw3-dev libgtk-3-dev
       if: matrix.os == 'ubuntu-latest' || matrix.os == 'ubuntu-24.04-arm'
+    - name: Install ZLIB (Windows)
+      if: matrix.os == 'windows-2022'
+      run: |
+        vcpkg install zlib:x64-windows
+        echo "CMAKE_PREFIX_PATH=C:/vcpkg/installed/x64-windows" >> $env:GITHUB_ENV
     - name: Install UV
       uses: astral-sh/setup-uv@v7
       with:

--- a/app.cpp
+++ b/app.cpp
@@ -13,7 +13,7 @@
 
 #include "widgets.h"
 
-#ifndef EMSCRIPTEN
+#ifndef __EMSCRIPTEN__
 #include "nfd.h"
 #endif
 
@@ -707,13 +707,13 @@ void MainGui() {
     auto viewport = ImGui::GetMainViewport();
     ImGui::SetNextWindowPos(viewport->Pos);
     ImGui::SetNextWindowSize(viewport->Size);
-#ifndef EMSCRIPTEN
+#ifndef __EMSCRIPTEN__
     ImGui::GetPlatformIO().Platform_SetWindowTitle(viewport, window_title);
 #endif
 
     ImGui::Begin(
         window_id,
-#ifndef EMSCRIPTEN
+#ifndef __EMSCRIPTEN__
         &appState.show_main_window,
 #else
         NULL,
@@ -721,7 +721,7 @@ void MainGui() {
         ImGuiWindowFlags_NoCollapse |
         ImGuiWindowFlags_NoMove |
         ImGuiWindowFlags_NoResize |
-#ifndef EMSCRIPTEN
+#ifndef __EMSCRIPTEN__
         // With Emscripten, we show the Dear ImGui titlebar,
         // but on desktop, the outer platform window has a titlebar already
         ImGuiWindowFlags_NoTitleBar |
@@ -967,7 +967,7 @@ void SaveTheme() {
 }
 
 std::string OpenFileDialog() {
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
     return "";
 #else
     nfdchar_t* outPath = NULL;
@@ -986,7 +986,7 @@ std::string OpenFileDialog() {
 }
 
 std::string SaveFileDialog() {
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
     return "";
 #else
     nfdchar_t* outPath = NULL;
@@ -1025,7 +1025,7 @@ void DrawMenu() {
             if (ImGui::MenuItem("Close Tab", NULL, false, GetActiveRoot())) {
                 CloseTab(appState.active_tab);
             }
-#ifndef EMSCRIPTEN
+#ifndef __EMSCRIPTEN__
             // You can't exit(0) from a web page
             // but you can on Desktop platforms.
             if (ImGui::MenuItem("Exit", "Alt+F4")) {

--- a/main.h
+++ b/main.h
@@ -4,7 +4,7 @@ void MainGui();
 void MainCleanup();
 void FileDropCallback(int count, const char** paths);
 
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
 extern "C" {
 void js_LoadUrl(char* url);
 void js_LoadString(char* json);


### PR DESCRIPTION
This PR fixes a couple of things to get CI working again:
* Fixes for ZLIB on Windows and Emscripten
* Use the newer __EMSCRIPTEN__ macro
* Use runners windows-2022 and macOS-14

Assisted-by: Claude:claude-fable-5-1 [debugging]
