### PR TITLE
Inspector: fixes media reference crashes

### DIFF
--- a/inspector.cpp
+++ b/inspector.cpp
@@ -780,13 +780,10 @@ void DrawInspector() {
 
         // Array of names and corresponding MediaReference pointers
         std::vector<const char*> reference_names;
-        otio::MediaReference** reference_objects = new otio::MediaReference*[media_references.size()];
-
-        size_t i = 0;
+        std::vector<otio::MediaReference*> reference_objects;
         for (const auto& media_reference : media_references) {
             reference_names.push_back(media_reference.first.c_str());
-            reference_objects[i] = media_reference.second;
-            i++;
+            reference_objects.push_back(media_reference.second);
         }
         int num_references = static_cast<int>(media_references.size());
 
@@ -803,7 +800,7 @@ void DrawInspector() {
         }
 
         // Set the active media ref key based on user selection
-        if (ImGui::Combo("", &appState.selected_reference_index, reference_names.data(), num_references)) {
+        if (ImGui::Combo("##media_reference", &appState.selected_reference_index, reference_names.data(), num_references)) {
             if (appState.selected_reference_index >= 0 && appState.selected_reference_index < num_references) {
                 clip->set_active_media_reference_key(reference_names[appState.selected_reference_index]);
             }


### PR DESCRIPTION
Occasionally there could be media reference inspector related crashes in our production files. I tracked down a couple of issues:

1. new otio::MediaReference*[] was never delete[]d. DrawInspector runs every frame and leaked continuously while a clip stayed selected. Replaced with std::vector.

2. ImGui derives each widgets internal ID by hashing its label. Empty string at the root of a window hashes to the same ID as the window itself. ImGui explicitly guards against this.

### Code assist disclosure

Assisted-by: Claude:claude-opus-4-8 [debugging]